### PR TITLE
modified collateral oracles

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -79,6 +79,8 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     address ETH_ORACLE_ADDRESS = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     address RETH_ORACLE_ADDRESS = 0x536218f9E9Eb48863970252233c8F271f554C2d0;
     address STETH_ORACLE_ADDRESS = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8;
+    address WSTETH_STETH_ORACLE_ADDRESS = 0xB1552C5e96B312d0Bf8b554186F846C40614a540;
+    address WSTETH_ETH_ORACLE_ADDRESS = 0xb523AE262D20A936BC152e6023996e46FDC2A95D;
     uint256 ETH_USD_STALENESS_THRESHOLD = 24 hours;
     uint256 STETH_USD_STALENESS_THRESHOLD = 24 hours;
     uint256 RETH_ETH_STALENESS_THRESHOLD = 48 hours;
@@ -331,9 +333,9 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
 
         TroveManagerParams[] memory troveManagerParamsArray = new TroveManagerParams[](3);
         // TODO: move params out of here
-        troveManagerParamsArray[0] = TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT/2); // WETH
-        troveManagerParamsArray[1] = TroveManagerParams(150e16, 120e16, 110e16, 110e16, 5e16, 10e16, MAX_INT/2); // wstETH
-        troveManagerParamsArray[2] = TroveManagerParams(150e16, 120e16, 110e16, 110e16, 5e16, 10e16, MAX_INT/2); // rETH
+        troveManagerParamsArray[0] = TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT / 2); // WETH
+        troveManagerParamsArray[1] = TroveManagerParams(150e16, 120e16, 110e16, 110e16, 5e16, 10e16, MAX_INT / 2); // wstETH
+        troveManagerParamsArray[2] = TroveManagerParams(150e16, 120e16, 110e16, 110e16, 5e16, 10e16, MAX_INT / 2); // rETH
 
         string[] memory collNames = new string[](2);
         string[] memory collSymbols = new string[](2);
@@ -554,24 +556,30 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
 
             // wstETH
             vars.collaterals[1] = IERC20Metadata(WSTETH_ADDRESS);
-            vars.priceFeeds[1] = new WSTETHPriceFeed(
-                deployer,
-                ETH_ORACLE_ADDRESS,
-                STETH_ORACLE_ADDRESS,
-                WSTETH_ADDRESS,
-                ETH_USD_STALENESS_THRESHOLD,
-                STETH_USD_STALENESS_THRESHOLD
+            vars.priceFeeds[1] = IPriceFeed(
+                address(
+                    new WSTETHPriceFeed(
+                        deployer,
+                        STETH_ORACLE_ADDRESS,
+                        WSTETH_STETH_ORACLE_ADDRESS,
+                        ETH_USD_STALENESS_THRESHOLD,
+                        STETH_USD_STALENESS_THRESHOLD
+                    )
+                )
             );
 
             // RETH
             vars.collaterals[2] = IERC20Metadata(RETH_ADDRESS);
-            vars.priceFeeds[2] = new RETHPriceFeed(
-                deployer,
-                ETH_ORACLE_ADDRESS,
-                RETH_ORACLE_ADDRESS,
-                RETH_ADDRESS,
-                ETH_USD_STALENESS_THRESHOLD,
-                RETH_ETH_STALENESS_THRESHOLD
+            vars.priceFeeds[2] = IPriceFeed(
+                address(
+                    new RETHPriceFeed(
+                        deployer,
+                        ETH_ORACLE_ADDRESS,
+                        RETH_ORACLE_ADDRESS,
+                        ETH_USD_STALENESS_THRESHOLD,
+                        RETH_ETH_STALENESS_THRESHOLD
+                    )
+                )
             );
         } else {
             // Sepolia

--- a/contracts/src/Interfaces/IApi3ReaderProxy.sol
+++ b/contracts/src/Interfaces/IApi3ReaderProxy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IApi3ReaderProxy {
+    function read() external view returns (int224 value, uint32 timestamp);
+}

--- a/contracts/src/Interfaces/IPUFETHPriceFeed.sol
+++ b/contracts/src/Interfaces/IPUFETHPriceFeed.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "./IApi3ReaderProxy.sol";
+
+interface IIPUFETHPriceFeed {
+    struct Api3Oracle {
+        IApi3ReaderProxy proxy;
+        uint256 stalenessThreshold;
+        uint256 decimals;
+    }
+
+    function pufEthOracle() external view returns (Api3Oracle memory, uint256, uint256);
+}

--- a/contracts/src/Interfaces/IRETHPriceFeed.sol
+++ b/contracts/src/Interfaces/IRETHPriceFeed.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
-import "./IMainnetPriceFeed.sol";
 import "../Dependencies/AggregatorV3Interface.sol";
 
 pragma solidity ^0.8.0;
 
-interface IRETHPriceFeed is IMainnetPriceFeed {
+interface IRETHPriceFeed {
     function rEthEthOracle() external view returns (AggregatorV3Interface, uint256, uint8);
 }

--- a/contracts/src/Interfaces/IWSTETHPriceFeed.sol
+++ b/contracts/src/Interfaces/IWSTETHPriceFeed.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
-import "./IMainnetPriceFeed.sol";
 import "../Dependencies/AggregatorV3Interface.sol";
 
 pragma solidity ^0.8.0;
 
-interface IWSTETHPriceFeed is IMainnetPriceFeed {
+interface IWSTETHPriceFeed {
     function stEthUsdOracle() external view returns (AggregatorV3Interface, uint256, uint8);
 }

--- a/contracts/src/PriceFeeds/PUFETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/PUFETHPriceFeed.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./TokenPriceFeedBase.sol";
+import "../Interfaces/IPUFETHPriceFeed.sol";
+import "forge-std/console2.sol";
+
+contract PUFETHPriceFeed is TokenPriceFeedBase, IIPUFETHPriceFeed {
+    // pufETH/stETH feed on arbitrum.
+    address public pufEthStEthOracleAddress = 0x26399f5229d893Cec6b89a3B52774d700582e1eF;
+    Api3Oracle internal _pufEthOracle;
+
+    constructor(
+        address _owner,
+        address _stEthUsdOracleAddress,
+        address _pufEthOracleAddress,
+        uint256 _stEthUsdStalenessThreshold,
+        uint256 _pufEthUsdStalenessThreshold
+    ) TokenPriceFeedBase(_owner, _stEthUsdOracleAddress, _stEthUsdStalenessThreshold) {
+        _pufEthOracle.proxy = IApi3ReaderProxy(_pufEthOracleAddress);
+        _pufEthOracle.stalenessThreshold = _pufEthUsdStalenessThreshold;
+        _pufEthOracle.decimals = 18;
+
+        priceSource = PriceSource.primary;
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function pufEthOracle() external view returns (Api3Oracle memory, uint256, uint256) {
+        return (_pufEthOracle, _pufEthOracle.stalenessThreshold, _pufEthOracle.decimals);
+    }
+
+    function _readApi3Oracle(Api3Oracle memory _oracle) internal view returns (int256, bool) {
+        (int224 oracleRateInt, uint32 pufEthStEthTimestamp) = _oracle.proxy.read();
+        int256 oracleRate = int256(oracleRateInt);
+
+        bool oracleIsDown = block.timestamp - pufEthStEthTimestamp > _oracle.stalenessThreshold;
+
+        if (oracleRate <= 0) {
+            oracleIsDown = true;
+        }
+
+        return (oracleRate, oracleIsDown);
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (int256 pufEthStEthRate, bool pufEthStEthOracleDown) = _readApi3Oracle(_pufEthOracle);
+        // ethUSD oracle is set to stEthUsd
+        (uint256 stEthUsdRate, bool stEthUsdOracleDown) = _getOracleAnswer(tokenUsdOracle);
+
+        // If the ETH-USD Chainlink response was invalid in this transaction, return the last good rsETH-USD price calculated
+        if (pufEthStEthOracleDown) {
+            _shutDownAndSwitchToLastGoodPrice(address(_pufEthOracle.proxy));
+        }
+        if (stEthUsdOracleDown) {
+            _shutDownAndSwitchToLastGoodPrice(address(tokenUsdOracle.aggregator));
+        }
+
+        uint256 pufEthUsdPrice = stEthUsdRate * uint256(pufEthStEthRate) / 1e18;
+
+        lastGoodPrice = pufEthUsdPrice;
+        return (pufEthUsdPrice, false);
+    }
+
+    function fetchRedemptionPrice() external returns (uint256, bool) {
+        return fetchPrice();
+    }
+}

--- a/contracts/src/PriceFeeds/RETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/RETHPriceFeed.sol
@@ -2,27 +2,24 @@
 
 pragma solidity 0.8.24;
 
-import "./CompositePriceFeed.sol";
+import "./TokenPriceFeedBase.sol";
 import "../Interfaces/IRETHToken.sol";
 import "../Interfaces/IRETHPriceFeed.sol";
 
 // import "forge-std/console2.sol";
 
-contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
+contract RETHPriceFeed is TokenPriceFeedBase, IRETHPriceFeed {
     constructor(
         address _owner,
         address _ethUsdOracleAddress,
         address _rEthEthOracleAddress,
-        address _rEthTokenAddress,
         uint256 _ethUsdStalenessThreshold,
         uint256 _rEthEthStalenessThreshold
-    ) CompositePriceFeed(_owner, _ethUsdOracleAddress, _rEthTokenAddress, _ethUsdStalenessThreshold) {
+    ) TokenPriceFeedBase(_owner, _ethUsdOracleAddress, _ethUsdStalenessThreshold) {
         // Store RETH-ETH oracle
         rEthEthOracle.aggregator = AggregatorV3Interface(_rEthEthOracleAddress);
         rEthEthOracle.stalenessThreshold = _rEthEthStalenessThreshold;
-        rEthEthOracle.decimals = rEthEthOracle.aggregator.decimals();
-
-        _fetchPricePrimary(false);
+        rEthEthOracle.decimals = 18;
 
         // Check the oracle didn't already fail
         assert(priceSource == PriceSource.primary);
@@ -32,69 +29,32 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
 
     uint256 public constant RETH_ETH_DEVIATION_THRESHOLD = 2e16; // 2%
 
-    function _fetchPricePrimary(bool _isRedemption) internal override returns (uint256, bool) {
+    function fetchPrice() public returns (uint256, bool) {
         assert(priceSource == PriceSource.primary);
-        (uint256 ethUsdPrice, bool ethUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+        (uint256 ethUsdPrice, bool ethUsdOracleDown) = _getOracleAnswer(tokenUsdOracle);
         (uint256 rEthEthPrice, bool rEthEthOracleDown) = _getOracleAnswer(rEthEthOracle);
-        (uint256 ethPerReth, bool exchangeRateIsDown) = _getCanonicalRate();
 
         // If either the ETH-USD feed or exchange rate is down, shut down and switch to the last good price
         // seen by the system since we need both for primary and fallback price calcs
         if (ethUsdOracleDown) {
-            return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
-        }
-        if (exchangeRateIsDown) {
-            return (_shutDownAndSwitchToLastGoodPrice(rateProviderAddress), true);
+            return (_shutDownAndSwitchToLastGoodPrice(address(tokenUsdOracle.aggregator)), true);
         }
         // If the ETH-USD feed is live but the RETH-ETH oracle is down, shutdown and substitute RETH-ETH with the canonical rate
         if (rEthEthOracleDown) {
-            return (_shutDownAndSwitchToETHUSDxCanonical(address(rEthEthOracle.aggregator), ethUsdPrice), true);
+            return (_shutDownAndSwitchToLastGoodPrice(address(rEthEthOracle.aggregator)), true);
         }
 
         // Otherwise, use the primary price calculation:
 
         // Calculate the market RETH-USD price: USD_per_RETH = USD_per_ETH * ETH_per_RETH
-        uint256 rEthUsdMarketPrice = ethUsdPrice * rEthEthPrice / 1e18;
-
-        // Calculate the canonical LST-USD price: USD_per_RETH = USD_per_ETH * ETH_per_RETH
-        uint256 rEthUsdCanonicalPrice = ethUsdPrice * ethPerReth / 1e18;
-
-        uint256 rEthUsdPrice;
-
-        // If it's a redemption and canonical is within 2% of market, use the max to mitigate unwanted redemption oracle arb
-        if (
-            _isRedemption
-                && _withinDeviationThreshold(rEthUsdMarketPrice, rEthUsdCanonicalPrice, RETH_ETH_DEVIATION_THRESHOLD)
-        ) {
-            rEthUsdPrice = LiquityMath._max(rEthUsdMarketPrice, rEthUsdCanonicalPrice);
-        } else {
-            // Take the minimum of (market, canonical) in order to mitigate against upward market price manipulation.
-            // Assumes a deviation between market <> canonical of >2% represents a legitimate market price difference.
-            rEthUsdPrice = LiquityMath._min(rEthUsdMarketPrice, rEthUsdCanonicalPrice);
-        }
+        uint256 rEthUsdPrice = ethUsdPrice * rEthEthPrice / 1e18;
 
         lastGoodPrice = rEthUsdPrice;
 
         return (rEthUsdPrice, false);
     }
 
-    function _getCanonicalRate() internal view override returns (uint256, bool) {
-        uint256 gasBefore = gasleft();
-
-        try IRETHToken(rateProviderAddress).getExchangeRate() returns (uint256 ethPerReth) {
-            // If rate is 0, return true
-            if (ethPerReth == 0) return (0, true);
-
-            return (ethPerReth, false);
-        } catch {
-            // Require that enough gas was provided to prevent an OOG revert in the external call
-            // causing a shutdown. Instead, just revert. Slightly conservative, as it includes gas used
-            // in the check itself.
-            if (gasleft() <= gasBefore / 64) revert InsufficientGasForExternalCall();
-
-
-            // If call to exchange rate reverts, return true
-            return (0, true);
-        }
+    function fetchRedemptionPrice() public returns (uint256, bool) {
+        return fetchPrice();
     }
 }

--- a/contracts/src/PriceFeeds/RSETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/RSETHPriceFeed.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "./MainnetPriceFeedBase.sol";
+import "forge-std/console2.sol";
+
+contract RSETHPriceFeed is MainnetPriceFeedBase {
+    //BTC feed on arbitrum.
+    address public rsEthOracleAddress = 0x8fE61e9D74ab69cE9185F365dfc21FC168c4B56c;
+    Oracle public rsEthOracle;
+
+    constructor(
+        address _owner,
+        address _ethUsdOracleAddress,
+        address _rsEthOracleAddress,
+        uint256 _ethUsdStalenessThreshold,
+        uint256 _rsEthUsdStalenessThreshold
+    ) MainnetPriceFeedBase(_owner, _ethUsdOracleAddress, _ethUsdStalenessThreshold) {
+        rsEthOracle.aggregator = AggregatorV3Interface(_rsEthOracleAddress);
+        rsEthOracle.stalenessThreshold = _rsEthUsdStalenessThreshold;
+        rsEthOracle.decimals = 18;
+        priceSource = PriceSource.primary;
+        // Check the oracle didn't already fail
+        assert(priceSource == PriceSource.primary);
+    }
+
+    function fetchRedemptionPrice() public returns (uint256, bool) {
+        return fetchPrice();
+    }
+
+    function fetchPrice() public returns (uint256, bool) {
+        assert(priceSource == PriceSource.primary);
+        (uint256 rsEthPrice, bool rsEthOracleDown) = _getOracleAnswer(rsEthOracle);
+        (uint256 ethUsdPrice, bool ethUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+
+        // If the ETH-USD Chainlink response was invalid in this transaction, return the last good rsETH-USD price calculated
+        if (rsEthOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(rsEthOracle.aggregator)), true);
+        if (ethUsdOracleDown) return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
+
+        // Calculate the canonical LST-USD price: USD_per_LST = USD_per_ETH * underlying_per_LST
+        uint256 rsEthUsdPrice = ethUsdPrice * rsEthPrice / 1e18;
+
+        lastGoodPrice = rsEthUsdPrice;
+        return (rsEthUsdPrice, false);
+    }
+}

--- a/contracts/src/PriceFeeds/TokenPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/TokenPriceFeedBase.sol
@@ -13,7 +13,7 @@ abstract contract TokenPriceFeedBase is Ownable {
     // - primary: Uses the primary price calcuation, which depends on the specific feed
     // - lastGoodPrice: the last good price recorded by this PriceFeed.
 
-     enum PriceSource {
+    enum PriceSource {
         primary,
         TokenUSDxCanonical,
         lastGoodPrice
@@ -51,7 +51,7 @@ abstract contract TokenPriceFeedBase is Ownable {
         tokenUsdOracle.stalenessThreshold = _tokenUsdStalenessThreshold;
         tokenUsdOracle.decimals = tokenUsdOracle.aggregator.decimals();
 
-        assert(tokenUsdOracle.decimals == 8);
+        assert(tokenUsdOracle.decimals == 8 || tokenUsdOracle.decimals == 18);
     }
 
     // TODO: remove this and set address in constructor, since we'll use CREATE2
@@ -109,7 +109,6 @@ abstract contract TokenPriceFeedBase is Ownable {
             // causing a shutdown. Instead, just revert. Slightly conservative, as it includes gas used
             // in the check itself.
             if (gasleft() <= gasBefore / 64) revert InsufficientGasForExternalCall();
-
 
             // If call to Chainlink aggregator reverts, return a zero response with success = false
             return chainlinkResponse;

--- a/contracts/src/PriceFeeds/WSTETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/WSTETHPriceFeed.sol
@@ -2,95 +2,63 @@
 
 pragma solidity 0.8.24;
 
-import "./CompositePriceFeed.sol";
+import "./TokenPriceFeedBase.sol";
 import "../Interfaces/IWSTETH.sol";
 import "../Interfaces/IWSTETHPriceFeed.sol";
 
 // import "forge-std/console2.sol";
 
-interface IWSTETH_Provider{
+interface IWSTETH_Provider {
     function getRate() external view returns (uint256);
 }
 
-contract WSTETHPriceFeed is CompositePriceFeed, IWSTETHPriceFeed {
-    Oracle public stEthUsdOracle;
-    IWSTETH_Provider public provider = IWSTETH_Provider(0xB1552C5e96B312d0Bf8b554186F846C40614a540);
-
+contract WSTETHPriceFeed is IWSTETHPriceFeed, TokenPriceFeedBase {
+    Oracle public wstEthStethOracle;
+    address public wStETHStEthOracle = 0xB1552C5e96B312d0Bf8b554186F846C40614a540;
 
     uint256 public constant STETH_USD_DEVIATION_THRESHOLD = 1e16; // 1%
 
     constructor(
         address _owner,
-        address _ethUsdOracleAddress,
         address _stEthUsdOracleAddress,
-        address _wstEthTokenAddress,
-        uint256 _ethUsdStalenessThreshold,
-        uint256 _stEthUsdStalenessThreshold
-    ) CompositePriceFeed(_owner, _ethUsdOracleAddress, _wstEthTokenAddress, _ethUsdStalenessThreshold) {
-        stEthUsdOracle.aggregator = AggregatorV3Interface(_stEthUsdOracleAddress);
-        stEthUsdOracle.stalenessThreshold = _stEthUsdStalenessThreshold;
-        stEthUsdOracle.decimals = stEthUsdOracle.aggregator.decimals();
+        address _wstEthStEthOracleAddress,
+        uint256 _stEthUsdStalenessThreshold,
+        uint256 _wstEthStEthStalenessThreshold
+    ) TokenPriceFeedBase(_owner, _stEthUsdOracleAddress, _stEthUsdStalenessThreshold) {
+        wstEthStethOracle.aggregator = AggregatorV3Interface(_wstEthStEthOracleAddress);
+        wstEthStethOracle.stalenessThreshold = _wstEthStEthStalenessThreshold;
+        wstEthStethOracle.decimals = wstEthStethOracle.aggregator.decimals();
 
-        _fetchPricePrimary(false);
-
+        priceSource = PriceSource.primary;
         // Check the oracle didn't already fail
         assert(priceSource == PriceSource.primary);
     }
 
-    function _fetchPricePrimary(bool _isRedemption) internal override returns (uint256, bool) {
+    function stEthUsdOracle() external view returns (AggregatorV3Interface, uint256, uint8) {
+        return (tokenUsdOracle.aggregator, tokenUsdOracle.stalenessThreshold, tokenUsdOracle.decimals);
+    }
+
+    function fetchPrice() external returns (uint256, bool) {
         assert(priceSource == PriceSource.primary);
-        (uint256 stEthUsdPrice, bool stEthUsdOracleDown) = _getOracleAnswer(stEthUsdOracle);
-        (uint256 stEthPerWstEth, bool exchangeRateIsDown) = _getCanonicalRate();
-        (uint256 ethUsdPrice, bool ethUsdOracleDown) = _getOracleAnswer(ethUsdOracle);
+        (uint256 stEthPerWstEth, bool stEthPerWstEthOracleDown) = _getOracleAnswer(wstEthStethOracle);
+        (uint256 stEthUsdPrice, bool stEthUsdOracleDown) = _getOracleAnswer(tokenUsdOracle);
 
         // - If exchange rate or ETH-USD is down, shut down and switch to last good price. Reasoning:
         // - Exchange rate is used in all price calcs
         // - ETH-USD is used in the fallback calc, and for redemptions in the primary price calc
-        if (exchangeRateIsDown) {
-            return (_shutDownAndSwitchToLastGoodPrice(rateProviderAddress), true);
+        if (stEthPerWstEthOracleDown) {
+            return (_shutDownAndSwitchToLastGoodPrice(address(wstEthStethOracle.aggregator)), true);
         }
-        if (ethUsdOracleDown) {
-            return (_shutDownAndSwitchToLastGoodPrice(address(ethUsdOracle.aggregator)), true);
-        }
-
         // If the STETH-USD feed is down, shut down and try to substitute it with the ETH-USD price
         if (stEthUsdOracleDown) {
-            return (_shutDownAndSwitchToETHUSDxCanonical(address(stEthUsdOracle.aggregator), ethUsdPrice), true);
+            return (_shutDownAndSwitchToLastGoodPrice(address(wstEthStethOracle.aggregator)), true);
         }
 
         // Otherwise, use the primary price calculation:
-        uint256 wstEthUsdPrice;
-
-        if (_isRedemption && _withinDeviationThreshold(stEthUsdPrice, ethUsdPrice, STETH_USD_DEVIATION_THRESHOLD)) {
-            // If it's a redemption and within 1%, take the max of (STETH-USD, ETH-USD) to mitigate unwanted redemption arb and convert to WSTETH-USD
-            wstEthUsdPrice = LiquityMath._max(stEthUsdPrice, ethUsdPrice) * stEthPerWstEth / 1e18;
-        } else {
-            // Otherwise, just calculate WSTETH-USD price: USD_per_WSTETH = USD_per_STETH * STETH_per_WSTETH
-            wstEthUsdPrice = stEthUsdPrice * stEthPerWstEth / 1e18;
-        }
+        uint256 wstEthUsdPrice = stEthUsdPrice * stEthPerWstEth / 1e18;
 
         lastGoodPrice = wstEthUsdPrice;
 
         return (wstEthUsdPrice, false);
-    }
-
-    function _getCanonicalRate() internal view override returns (uint256, bool) {
-        uint256 gasBefore = gasleft();
-
-        try provider.getRate() returns (uint256 stEthPerWstEth) {
-            // If rate is 0, return true
-            if (stEthPerWstEth == 0) return (0, true);
-
-            return (stEthPerWstEth, false);
-        } catch {
-            // Require that enough gas was provided to prevent an OOG revert in the external call
-            // causing a shutdown. Instead, just revert. Slightly conservative, as it includes gas used
-            // in the check itself.
-            if (gasleft() <= gasBefore / 64) revert InsufficientGasForExternalCall();
-
-
-            // If call to exchange rate reverted for another reason, return true
-            return (0, true);
-        }
     }
 }

--- a/contracts/test/ArbitrumOracle.t.sol
+++ b/contracts/test/ArbitrumOracle.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "src/PriceFeeds/WSTETHPriceFeed.sol";
+import "src/PriceFeeds/MainnetPriceFeedBase.sol";
+import "src/PriceFeeds/RETHPriceFeed.sol";
+import "src/PriceFeeds/WETHPriceFeed.sol";
+
+import "./TestContracts/Accounts.sol";
+import "./TestContracts/ChainlinkOracleMock.sol";
+import "./TestContracts/GasGuzzlerOracle.sol";
+import "./TestContracts/GasGuzzlerToken.sol";
+import "./TestContracts/RETHTokenMock.sol";
+import "./TestContracts/WSTETHTokenMock.sol";
+import "./TestContracts/Deployment.t.sol";
+
+import "src/Dependencies/AggregatorV3Interface.sol";
+import "src/PriceFeeds/RETHPriceFeed.sol";
+import "src/Interfaces/IWSTETHPriceFeed.sol";
+import "src/PriceFeeds/WSTETHPriceFeed.sol";
+import "src/PriceFeeds/RSETHPriceFeed.sol";
+import "src/PriceFeeds/PUFETHPriceFeed.sol";
+
+import "src/Interfaces/IRETHToken.sol";
+import "src/Interfaces/IWSTETH.sol";
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+
+contract ArbitrumOracles is Test {
+    RSETHPriceFeed public rsETHPriceFeed;
+    PUFETHPriceFeed public pufETHPriceFeed;
+    WSTETHPriceFeed public wstethPriceFeed;
+    RETHPriceFeed public rEthPriceFeed;
+
+    // chainlink addresses
+    address public WSTETH_ADDRESS = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+    address public RETH_ADDRESS = 0xae78736Cd615f374D3085123A210448E74Fc6393;
+    address public ETH_ORACLE_ADDRESS = 0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612;
+    address public RSETH_ORACLE_ADDRESS = 0x8fE61e9D74ab69cE9185F365dfc21FC168c4B56c;
+    address public RETH_ORACLE_ADDRESS = 0xD6aB2298946840262FcC278fF31516D39fF611eF;
+    address public STETH_ORACLE_ADDRESS = 0x07C5b924399cc23c24a95c8743DE4006a32b7f2a;
+    address public WSTETH_STETH_ORACLE_ADDRESS = 0xB1552C5e96B312d0Bf8b554186F846C40614a540;
+    address public WSTETH_ETH_ORACLE_ADDRESS = 0xb523AE262D20A936BC152e6023996e46FDC2A95D;
+
+    // api3 addresses
+    address public PUFFETH_ORACLE_ADDRESS = 0x26399f5229d893Cec6b89a3B52774d700582e1eF;
+
+    function setUp() public {
+        string memory arbitrumRpcUrl = vm.envString("ARBITRUM_RPC_URL");
+        vm.createSelectFork(arbitrumRpcUrl);
+        rEthPriceFeed = _deployRETH();
+        wstethPriceFeed = _deployWSTETH();
+        rsETHPriceFeed = _deployRsETH();
+        pufETHPriceFeed = _deployPufETH();
+    }
+
+    function _deployRsETH() internal returns (RSETHPriceFeed _rsETHPriceFeed) {
+        _rsETHPriceFeed =
+            new RSETHPriceFeed(address(this), ETH_ORACLE_ADDRESS, RSETH_ORACLE_ADDRESS, 24 hours, 24 hours);
+        vm.label(address(_rsETHPriceFeed), "RSETHPriceFeed");
+    }
+
+    function _deployPufETH() internal returns (PUFETHPriceFeed _pufETHPriceFeed) {
+        _pufETHPriceFeed =
+            new PUFETHPriceFeed(address(this), STETH_ORACLE_ADDRESS, PUFFETH_ORACLE_ADDRESS, 24 hours, 24 hours);
+        vm.label(address(_pufETHPriceFeed), "PUFETHPriceFeed");
+    }
+
+    function _deployWSTETH() internal returns (WSTETHPriceFeed _wstethPriceFeed) {
+        _wstethPriceFeed = new WSTETHPriceFeed(
+            address(this), WSTETH_STETH_ORACLE_ADDRESS, WSTETH_ETH_ORACLE_ADDRESS, 24 hours, 24 hours
+        );
+        vm.label(address(_wstethPriceFeed), "WSTETHPriceFeed");
+    }
+
+    function _deployRETH() internal returns (RETHPriceFeed _rEthPriceFeed) {
+        _rEthPriceFeed = new RETHPriceFeed(address(this), ETH_ORACLE_ADDRESS, RETH_ORACLE_ADDRESS, 24 hours, 24 hours);
+        vm.label(address(_rEthPriceFeed), "RETHPriceFeed");
+    }
+
+    function test_rsETHPriceFeed() public {
+        (uint256 price, bool oracleDown) = rsETHPriceFeed.fetchPrice();
+
+        assertGt(price, 0, "rsEth Price must not be zero");
+        assertFalse(oracleDown, "rsEth oracle must not be down");
+    }
+
+    function test_pufETHPriceFeed() public {
+        (uint256 price, bool oracleDown) = pufETHPriceFeed.fetchPrice();
+
+        assertGt(price, 0, "pufEth Price must not be zero");
+        assertFalse(oracleDown, "pufEth oracle must not be down");
+    }
+
+    function test_wstethPriceFeed() public {
+        (uint256 price, bool oracleDown) = wstethPriceFeed.fetchPrice();
+
+        assertGt(price, 0, "wstEth Price must not be zero");
+        assertFalse(oracleDown, "wstEth oracle must not be down");
+    }
+
+    function test_rEthPriceFeed() public {
+        (uint256 price, bool oracleDown) = rEthPriceFeed.fetchPrice();
+
+        assertGt(price, 0, "rEth Price must not be zero");
+        assertFalse(oracleDown, "rEth oracle must not be down");
+    }
+}

--- a/contracts/test/OracleMainnet.t.sol
+++ b/contracts/test/OracleMainnet.t.sol
@@ -16,8 +16,8 @@ import "./TestContracts/WSTETHTokenMock.sol";
 import "./TestContracts/Deployment.t.sol";
 
 import "src/Dependencies/AggregatorV3Interface.sol";
-import "src/Interfaces/IRETHPriceFeed.sol";
-import "src/Interfaces/IWSTETHPriceFeed.sol";
+import "src/PriceFeeds/RETHPriceFeed.sol";
+import "src/PriceFeeds/WSTETHPriceFeed.sol";
 
 import "src/Interfaces/IRETHToken.sol";
 import "src/Interfaces/IWSTETH.sol";
@@ -26,7 +26,6 @@ import "forge-std/Test.sol";
 import "lib/forge-std/src/console2.sol";
 
 contract OraclesMainnet is TestAccounts {
-
     uint256 constant MAX_INT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     AggregatorV3Interface ethOracle;
     AggregatorV3Interface stethOracle;
@@ -37,8 +36,8 @@ contract OraclesMainnet is TestAccounts {
     GasGuzzlerOracle gasGuzzlerOracle;
 
     IMainnetPriceFeed wethPriceFeed;
-    IRETHPriceFeed rethPriceFeed;
-    IWSTETHPriceFeed wstethPriceFeed;
+    RETHPriceFeed rethPriceFeed;
+    WSTETHPriceFeed wstethPriceFeed;
 
     IRETHToken rethToken;
     IWSTETH wstETH;
@@ -81,7 +80,7 @@ contract OraclesMainnet is TestAccounts {
 
         vars.numCollaterals = 3;
         TestDeployer.TroveManagerParams memory tmParams =
-            TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT/2);
+            TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT / 2);
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](vars.numCollaterals);
         for (uint256 i = 0; i < troveManagerParamsArray.length; i++) {
@@ -131,8 +130,8 @@ contract OraclesMainnet is TestAccounts {
         }
 
         wethPriceFeed = IMainnetPriceFeed(address(contractsArray[0].priceFeed));
-        rethPriceFeed = IRETHPriceFeed(address(contractsArray[1].priceFeed));
-        wstethPriceFeed = IWSTETHPriceFeed(address(contractsArray[2].priceFeed));
+        rethPriceFeed = RETHPriceFeed(address(contractsArray[1].priceFeed));
+        wstethPriceFeed = WSTETHPriceFeed(address(contractsArray[2].priceFeed));
 
         // log some current blockchain state
         // console2.log(block.timestamp, "block.timestamp");
@@ -331,7 +330,7 @@ contract OraclesMainnet is TestAccounts {
     }
 
     function testEthUsdStalenessThresholdSetRETH() public view {
-        (, uint256 storedEthUsdStaleness,) = rethPriceFeed.ethUsdOracle();
+        (, uint256 storedEthUsdStaleness,) = rethPriceFeed.tokenUsdOracle();
         assertEq(storedEthUsdStaleness, _24_HOURS);
     }
 

--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -50,8 +50,7 @@ import {SuperfluidFrameworkDeployer} from
     "@superfluid-finance/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.t.sol";
 import {ERC1820RegistryCompiled} from
     "@superfluid-finance/ethereum-contracts/contracts/libs/ERC1820RegistryCompiled.sol";
-import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
-
+import {SuperTokenV1Library} from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
 
 import "forge-std/console2.sol";
 
@@ -204,6 +203,7 @@ contract TestDeployer is MetadataDeployment {
         address RETHOracle;
         address WSTETHToken;
         address RETHToken;
+        address WSTETHOracle;
     }
 
     struct OracleParams {
@@ -217,7 +217,11 @@ contract TestDeployer is MetadataDeployment {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry));
     }
 
-    function getBytecodeWithGovernor(bytes memory _creationCode, address _addressesRegistry, address _governor) public pure returns (bytes memory) {
+    function getBytecodeWithGovernor(bytes memory _creationCode, address _addressesRegistry, address _governor)
+        public
+        pure
+        returns (bytes memory)
+    {
         return abi.encodePacked(_creationCode, abi.encode(_addressesRegistry, _governor));
     }
 
@@ -242,7 +246,7 @@ contract TestDeployer is MetadataDeployment {
             Zappers memory zappers
         )
     {
-        return deployAndConnectContracts(TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT/2));
+        return deployAndConnectContracts(TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, MAX_INT / 2));
     }
 
     function deployAndConnectContracts(TroveManagerParams memory troveManagerParams)
@@ -444,7 +448,9 @@ contract TestDeployer is MetadataDeployment {
         );
         addresses.troveManager = _troveManagerAddress;
         addresses.troveNFT = getAddress(
-            address(this), getBytecodeWithGovernor(type(TroveNFT).creationCode, address(contracts.addressesRegistry), address(0)), SALT
+            address(this),
+            getBytecodeWithGovernor(type(TroveNFT).creationCode, address(contracts.addressesRegistry), address(0)),
+            SALT
         );
         addresses.stabilityPool = getAddress(
             address(this), getBytecode(type(StabilityPool).creationCode, address(contracts.addressesRegistry)), SALT
@@ -536,7 +542,6 @@ contract TestDeployer is MetadataDeployment {
         public
         returns (DeploymentResultMainnet memory result)
     {
-
         //setup SF factories.
         ISuperTokenFactory superTokenFactory = ISuperTokenFactory(0x0000000000000000000000000000000000000000);
 
@@ -546,7 +551,7 @@ contract TestDeployer is MetadataDeployment {
         result.externalAddresses.RETHOracle = 0x536218f9E9Eb48863970252233c8F271f554C2d0;
         result.externalAddresses.STETHOracle = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8;
         result.externalAddresses.WSTETHToken = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
-
+        result.externalAddresses.WSTETHOracle = 0x164b276057258d81941e97B0a900D4C7B358bCe0;
         result.externalAddresses.RETHToken = 0xae78736Cd615f374D3085123A210448E74Fc6393;
 
         vars.oracleParams.ethUsdStalenessThreshold = _24_HOURS;
@@ -570,23 +575,29 @@ contract TestDeployer is MetadataDeployment {
         );
 
         // RETH
-        vars.priceFeeds[1] = new RETHPriceFeed(
-            address(this),
-            result.externalAddresses.ETHOracle,
-            result.externalAddresses.RETHOracle,
-            result.externalAddresses.RETHToken,
-            vars.oracleParams.ethUsdStalenessThreshold,
-            vars.oracleParams.rEthEthStalenessThreshold
+        vars.priceFeeds[1] = IPriceFeed(
+            address(
+                new RETHPriceFeed(
+                    address(this),
+                    result.externalAddresses.ETHOracle,
+                    result.externalAddresses.RETHOracle,
+                    vars.oracleParams.ethUsdStalenessThreshold,
+                    vars.oracleParams.rEthEthStalenessThreshold
+                )
+            )
         );
 
         // wstETH
-        vars.priceFeeds[2] = new WSTETHPriceFeed(
-            address(this),
-            result.externalAddresses.ETHOracle,
-            result.externalAddresses.STETHOracle,
-            result.externalAddresses.WSTETHToken,
-            vars.oracleParams.ethUsdStalenessThreshold,
-            vars.oracleParams.stEthUsdStalenessThreshold
+        vars.priceFeeds[2] = IPriceFeed(
+            address(
+                new WSTETHPriceFeed(
+                    address(this),
+                    result.externalAddresses.STETHOracle,
+                    result.externalAddresses.WSTETHOracle,
+                    vars.oracleParams.ethUsdStalenessThreshold,
+                    vars.oracleParams.stEthUsdStalenessThreshold
+                )
+            )
         );
 
         // Deploy Bold
@@ -688,7 +699,9 @@ contract TestDeployer is MetadataDeployment {
         );
         addresses.troveManager = _params.troveManagerAddress;
         addresses.troveNFT = getAddress(
-            address(this), getBytecodeWithGovernor(type(TroveNFT).creationCode, address(contracts.addressesRegistry), address(0)), SALT
+            address(this),
+            getBytecodeWithGovernor(type(TroveNFT).creationCode, address(contracts.addressesRegistry), address(0)),
+            SALT
         );
         addresses.stabilityPool = getAddress(
             address(this), getBytecode(type(StabilityPool).creationCode, address(contracts.addressesRegistry)), SALT


### PR DESCRIPTION
brought over only necessary changes. 

note:  base protocol fork tests for oracles no longer work since the wsteth oracle uses a wsteth/eth oracle while mainnet uses wsteth/usd oracle