### PR TITLE
Require Zapper to be the receiver for Remove operations

### DIFF
--- a/contracts/src/Zappers/BaseZapper.sol
+++ b/contracts/src/Zappers/BaseZapper.sol
@@ -33,6 +33,11 @@ abstract contract BaseZapper is AddRemoveManagers, LeftoversSweep, IFlashLoanRec
         exchange = _exchange;
     }
 
+    function _requireZapperIsReceiver(uint256 _troveId) internal view {
+        (, address receiver) = borrowerOperations.removeManagerReceiverOf(_troveId);
+        require(receiver == address(this), "BZ: Zapper is not receiver for this trove");
+    }
+
     function _checkAdjustTroveManagers(
         uint256 _troveId,
         uint256 _collChange,
@@ -44,6 +49,7 @@ abstract contract BaseZapper is AddRemoveManagers, LeftoversSweep, IFlashLoanRec
 
         if ((!_isCollIncrease && _collChange > 0) || _isDebtIncrease) {
             receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_troveId, owner);
+            _requireZapperIsReceiver(_troveId);
         } else {
             // RemoveManager assumes AddManager, so if the former is set, there's no need to check the latter
             _requireSenderIsOwnerOrAddManager(_troveId, owner);
@@ -55,4 +61,6 @@ abstract contract BaseZapper is AddRemoveManagers, LeftoversSweep, IFlashLoanRec
 
         return receiver;
     }
+
+    
 }

--- a/contracts/src/Zappers/GasCompZapper.sol
+++ b/contracts/src/Zappers/GasCompZapper.sol
@@ -102,6 +102,7 @@ contract GasCompZapper is BaseZapper {
     function withdrawColl(uint256 _troveId, uint256 _amount) external {
         address owner = troveNFT.ownerOf(_troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_troveId, owner);
+        _requireZapperIsReceiver(_troveId);
 
         borrowerOperations.withdrawColl(_troveId, _amount);
 
@@ -112,6 +113,7 @@ contract GasCompZapper is BaseZapper {
     function withdrawBold(uint256 _troveId, uint256 _boldAmount, uint256 _maxUpfrontFee) external {
         address owner = troveNFT.ownerOf(_troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_troveId, owner);
+        _requireZapperIsReceiver(_troveId);
 
         borrowerOperations.withdrawBold(_troveId, _boldAmount, _maxUpfrontFee);
 
@@ -224,6 +226,7 @@ contract GasCompZapper is BaseZapper {
     function closeTroveToRawETH(uint256 _troveId) external {
         address owner = troveNFT.ownerOf(_troveId);
         address payable receiver = payable(_requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_troveId, owner));
+        _requireZapperIsReceiver(_troveId);
 
         // pull Bold for repayment
         LatestTroveData memory trove = troveManager.getLatestTroveData(_troveId);
@@ -243,6 +246,8 @@ contract GasCompZapper is BaseZapper {
     function closeTroveFromCollateral(uint256 _troveId, uint256 _flashLoanAmount) external override {
         address owner = troveNFT.ownerOf(_troveId);
         address payable receiver = payable(_requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_troveId, owner));
+        _requireZapperIsReceiver(_troveId);
+
         CloseTroveParams memory params =
             CloseTroveParams({troveId: _troveId, flashLoanAmount: _flashLoanAmount, receiver: receiver});
 

--- a/contracts/src/Zappers/LeverageLSTZapper.sol
+++ b/contracts/src/Zappers/LeverageLSTZapper.sol
@@ -108,6 +108,7 @@ contract LeverageLSTZapper is GasCompZapper, ILeverageZapper {
     function leverUpTrove(LeverUpTroveParams calldata _params) external {
         address owner = troveNFT.ownerOf(_params.troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_params.troveId, owner);
+        _requireZapperIsReceiver(_params.troveId);
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;
@@ -153,6 +154,7 @@ contract LeverageLSTZapper is GasCompZapper, ILeverageZapper {
     function leverDownTrove(LeverDownTroveParams calldata _params) external {
         address owner = troveNFT.ownerOf(_params.troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_params.troveId, owner);
+        _requireZapperIsReceiver(_params.troveId);
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;

--- a/contracts/src/Zappers/LeverageWETHZapper.sol
+++ b/contracts/src/Zappers/LeverageWETHZapper.sol
@@ -103,6 +103,7 @@ contract LeverageWETHZapper is WETHZapper, ILeverageZapper {
     function leverUpTrove(LeverUpTroveParams calldata _params) external {
         address owner = troveNFT.ownerOf(_params.troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_params.troveId, owner);
+        _requireZapperIsReceiver(_params.troveId);
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;
@@ -148,6 +149,7 @@ contract LeverageWETHZapper is WETHZapper, ILeverageZapper {
     function leverDownTrove(LeverDownTroveParams calldata _params) external {
         address owner = troveNFT.ownerOf(_params.troveId);
         address receiver = _requireSenderIsOwnerOrRemoveManagerAndGetReceiver(_params.troveId, owner);
+        _requireZapperIsReceiver(_params.troveId);
 
         // Set initial balances to make sure there are not lefovers
         InitialBalances memory initialBalances;

--- a/contracts/test/zapperGasComp.t.sol
+++ b/contracts/test/zapperGasComp.t.sol
@@ -27,8 +27,8 @@ contract ZapperGasCompTest is DevTestSetup {
         WETH = new WETH9();
 
         TestDeployer.TroveManagerParams[] memory troveManagerParams = new TestDeployer.TroveManagerParams[](2);
-        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e16);
-        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e16);
+        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e24);
+        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e24);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory contractsArray;

--- a/contracts/test/zapperGasComp.t.sol
+++ b/contracts/test/zapperGasComp.t.sol
@@ -27,8 +27,8 @@ contract ZapperGasCompTest is DevTestSetup {
         WETH = new WETH9();
 
         TestDeployer.TroveManagerParams[] memory troveManagerParams = new TestDeployer.TroveManagerParams[](2);
-        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, type(uint256).max);
-        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, type(uint256).max);
+        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e16);
+        troveManagerParams[1] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e16);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory contractsArray;
@@ -229,6 +229,37 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(collToken.balanceOf(A), collBalanceBefore + collAmount2, "Coll bal mismatch");
     }
 
+    function testCanontWithdrawCollIfZapperIsNotReceiver() external {
+        uint256 collAmount1 = 10 ether;
+        uint256 boldAmount = 10000e18;
+        uint256 collAmount2 = 1 ether;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount1,
+            boldAmount: boldAmount,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: 5e16,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Change receiver
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), B);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.withdrawColl(troveId, collAmount2);
+        vm.stopPrank();
+    }
+
     function testCanNotAddReceiverWithoutRemoveManager() external {
         uint256 collAmount = 10 ether;
         uint256 boldAmount1 = 10000e18;
@@ -356,6 +387,43 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(collToken.balanceOf(B), collBalanceBeforeB, "B Coll bal mismatch");
     }
 
+    function testCannotWithdrawBoldIfZapperIsNotReceiver() external {
+        uint256 collAmount = 10 ether;
+        uint256 boldAmount1 = 10000e18;
+        uint256 boldAmount2 = 1000e18;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount,
+            boldAmount: boldAmount1,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Add a remove manager for the zapper
+        gasCompZapper.setRemoveManagerWithReceiver(troveId, B, A);
+        // Change receiver in BO
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), B);
+        vm.stopPrank();
+
+        // Withdraw bold
+        vm.startPrank(B);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.withdrawBold(troveId, boldAmount2, boldAmount2);
+        vm.stopPrank();
+    }
+
     function testCanAdjustTroveWithdrawCollAndBold() external {
         uint256 collAmount1 = 10 ether;
         uint256 collAmount2 = 1 ether;
@@ -405,6 +473,44 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(collToken.balanceOf(B), collBalanceBeforeB, "B Coll bal mismatch");
     }
 
+    function testCannotAdjustTroveWithdrawCollAndBoldIfZapperIsNotReceiver() external {
+        uint256 collAmount1 = 10 ether;
+        uint256 collAmount2 = 1 ether;
+        uint256 boldAmount1 = 10000e18;
+        uint256 boldAmount2 = 1000e18;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount1,
+            boldAmount: boldAmount1,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Add a remove manager for the zapper
+        gasCompZapper.setRemoveManagerWithReceiver(troveId, B, A);
+        // Change receiver in BO
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), B);
+        vm.stopPrank();
+
+        // Adjust (withdraw coll and Bold)
+        vm.startPrank(B);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.adjustTrove(troveId, collAmount2, false, boldAmount2, true, boldAmount2);
+        vm.stopPrank();
+    }
+
     function testCanAdjustTroveAddCollAndWithdrawBold() external {
         uint256 collAmount1 = 10 ether;
         uint256 collAmount2 = 1 ether;
@@ -452,6 +558,44 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(collToken.balanceOf(A), collBalanceBeforeA, "A Coll bal mismatch");
         assertEq(boldToken.balanceOf(B), boldBalanceBeforeB, "B BOLD bal mismatch");
         assertEq(collToken.balanceOf(B), collBalanceBeforeB - collAmount2, "B Coll bal mismatch");
+    }
+
+    function testCannotAdjustTroveAddCollAndWithdrawBoldIfZapperIsNotReceiver() external {
+        uint256 collAmount1 = 10 ether;
+        uint256 collAmount2 = 1 ether;
+        uint256 boldAmount1 = 10000e18;
+        uint256 boldAmount2 = 1000e18;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount1,
+            boldAmount: boldAmount1,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Add a remove manager for the zapper
+        gasCompZapper.setRemoveManagerWithReceiver(troveId, B, A);
+        // Change receiver in BO
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), B);
+        vm.stopPrank();
+
+        // Adjust (add coll and withdraw Bold)
+        vm.startPrank(B);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.adjustTrove(troveId, collAmount2, true, boldAmount2, true, boldAmount2);
+        vm.stopPrank();
     }
 
     // TODO: more adjustment combinations
@@ -505,6 +649,49 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(collToken.balanceOf(A), collBalanceBeforeA + collAmount2, "A Coll bal mismatch");
         assertEq(boldToken.balanceOf(B), 0, "B BOLD bal mismatch");
         assertEq(collToken.balanceOf(B), collBalanceBeforeB, "B Coll bal mismatch");
+    }
+
+    function testCannotAdjustZombieTroveWithdrawCollAndBoldIfZapperIsNotReceiver() external {
+        uint256 collAmount1 = 10 ether;
+        uint256 collAmount2 = 1 ether;
+        uint256 boldAmount1 = 10000e18;
+        uint256 boldAmount2 = 1000e18;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount1,
+            boldAmount: boldAmount1,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Add a remove manager for the zapper
+        gasCompZapper.setRemoveManagerWithReceiver(troveId, B, A);
+        // Change receiver in BO
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), B);
+        vm.stopPrank();
+
+        // Redeem to make trove zombie
+        vm.startPrank(A);
+        collateralRegistry.redeemCollateral(boldAmount1 - boldAmount2, 10, 1e18);
+        vm.stopPrank();
+
+        // Adjust (withdraw coll and Bold)
+        vm.startPrank(B);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.adjustZombieTrove(troveId, collAmount2, false, boldAmount2, true, 0, 0, boldAmount2);
+        vm.stopPrank();
     }
 
     function testCanCloseTrove() external {
@@ -564,6 +751,59 @@ contract ZapperGasCompTest is DevTestSetup {
         assertEq(boldToken.balanceOf(A), 0, "BOLD bal mismatch");
         assertEq(A.balance, ethBalanceBefore, "ETH bal mismatch");
         assertEq(collToken.balanceOf(A), collBalanceBefore, "Coll bal mismatch");
+    }
+
+    function testCannotCloseTroveIfZapperIsNotReceiver() external {
+        uint256 collAmount = 10 ether;
+        uint256 boldAmount = 10000e18;
+
+        IZapper.OpenTroveParams memory params = IZapper.OpenTroveParams({
+            owner: A,
+            ownerIndex: 0,
+            collAmount: collAmount,
+            boldAmount: boldAmount,
+            upperHint: 0,
+            lowerHint: 0,
+            annualInterestRate: MIN_ANNUAL_INTEREST_RATE,
+            batchManager: address(0),
+            maxUpfrontFee: 1000e18,
+            addManager: address(0),
+            removeManager: address(0),
+            receiver: address(0)
+        });
+        vm.startPrank(A);
+        uint256 troveId = gasCompZapper.openTroveWithRawETH{value: ETH_GAS_COMPENSATION}(params);
+        vm.stopPrank();
+
+        // open a 2nd trove so we can close the 1st one, and send Bold to account for interest and fee
+        vm.startPrank(B);
+        deal(address(WETH), B, ETH_GAS_COMPENSATION);
+        WETH.approve(address(borrowerOperations), ETH_GAS_COMPENSATION);
+        deal(address(collToken), B, 100 ether);
+        collToken.approve(address(borrowerOperations), 100 ether);
+        borrowerOperations.openTrove(
+            B,
+            0, // index,
+            100 ether, // coll,
+            10000e18, //boldAmount,
+            0, // _upperHint
+            0, // _lowerHint
+            MIN_ANNUAL_INTEREST_RATE, // annualInterestRate,
+            10000e18, // upfrontFee
+            address(0),
+            address(0),
+            address(0)
+        );
+        boldToken.transfer(A, troveManager.getTroveEntireDebt(troveId) - boldAmount);
+        vm.stopPrank();
+
+        vm.startPrank(A);
+        // Change receiver in BO
+        borrowerOperations.setRemoveManagerWithReceiver(troveId, address(gasCompZapper), C);
+        boldToken.approve(address(gasCompZapper), type(uint256).max);
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        gasCompZapper.closeTroveToRawETH(troveId);
+        vm.stopPrank();
     }
 
     function testExcessRepaymentByAdjustGoesBackToUser() external {

--- a/contracts/test/zapperLeverage.t.sol
+++ b/contracts/test/zapperLeverage.t.sol
@@ -126,9 +126,9 @@ contract ZapperLeverageMainnet is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e18);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e24);
         for (uint256 c = 0; c < NUM_COLLATERALS; c++) {
-            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e18);
+            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e24);
         }
 
         TestDeployer deployer = new TestDeployer();

--- a/contracts/test/zapperLeverage.t.sol
+++ b/contracts/test/zapperLeverage.t.sol
@@ -126,9 +126,9 @@ contract ZapperLeverageMainnet is DevTestSetup {
 
         TestDeployer.TroveManagerParams[] memory troveManagerParamsArray =
             new TestDeployer.TroveManagerParams[](NUM_COLLATERALS);
-        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, type(uint256).max);
-        for (uint256 c = 1; c < NUM_COLLATERALS; c++) {
-            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, type(uint256).max);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e18);
+        for (uint256 c = 0; c < NUM_COLLATERALS; c++) {
+            troveManagerParamsArray[c] = TestDeployer.TroveManagerParams(160e16, 120e16, 10e16, 120e16, 5e16, 10e16, 10e18);
         }
 
         TestDeployer deployer = new TestDeployer();
@@ -696,6 +696,80 @@ contract ZapperLeverageMainnet is DevTestSetup {
         assertEq(address(_leverageZapper.flashLoanProvider().receiver()), address(0), "Receiver should be zero");
     }
 
+    function testCannotLeverUpTroveWithCurveIfZapperIsNotReceiver() external {
+        for (uint256 i = 0; i < NUM_COLLATERALS; i++) {
+            _testCannotLeverUpTroveIfZapperIsNotReceiver(leverageZapperCurveArray[i], ExchangeType.Curve, i);
+        }
+    }
+
+    function testCannotLeverUpTroveWithUniV3IfZapperIsNotReceiver() external {
+        for (uint256 i = 0; i < NUM_COLLATERALS; i++) {
+            _testCannotLeverUpTroveIfZapperIsNotReceiver(leverageZapperUniV3Array[i], ExchangeType.UniV3, i);
+        }
+    }
+
+    function testCannotLeverUpTroveWithHybridIfZapperIsNotReceiver() external {
+        // Not enough liquidity for ETHx
+        for (uint256 i = 0; i < 3; i++) {
+            _testCannotLeverUpTroveIfZapperIsNotReceiver(leverageZapperHybridArray[i], ExchangeType.HybridCurveUniV3, i);
+        }
+    }
+
+    function _testCannotLeverUpTroveIfZapperIsNotReceiver(
+        ILeverageZapper _leverageZapper,
+        ExchangeType _exchangeType,
+        uint256 _branch
+    ) internal {
+        TestVars memory vars;
+        vars.collAmount = 10 ether;
+        vars.initialLeverageRatio = 2e18;
+
+        OpenLeveragedTroveWithIndexParams memory openTroveParams;
+        openTroveParams.leverageZapper = _leverageZapper;
+        openTroveParams.collToken = contractsArray[_branch].collToken;
+        openTroveParams.index = 0;
+        openTroveParams.collAmount = vars.collAmount;
+        openTroveParams.leverageRatio = vars.initialLeverageRatio;
+        openTroveParams.priceFeed = contractsArray[_branch].priceFeed;
+        openTroveParams.exchangeType = _exchangeType;
+        openTroveParams.branch = _branch;
+        openTroveParams.batchManager = address(0);
+        (vars.troveId,) = openLeveragedTroveWithIndex(openTroveParams);
+
+        vars.initialDebt = getTroveEntireDebt(contractsArray[_branch].troveManager, vars.troveId);
+
+        vars.newLeverageRatio = 2.5e18;
+        vars.resultingCollateralRatio = _leverageZapper.leverageRatioToCollateralRatio(vars.newLeverageRatio);
+
+        LeverUpParams memory getterParams;
+        getterParams.leverageZapper = _leverageZapper;
+        getterParams.collToken = contractsArray[_branch].collToken;
+        getterParams.troveId = vars.troveId;
+        getterParams.leverageRatio = vars.newLeverageRatio;
+        getterParams.troveManager = contractsArray[_branch].troveManager;
+        getterParams.priceFeed = contractsArray[_branch].priceFeed;
+        getterParams.exchangeType = _exchangeType;
+        getterParams.branch = _branch;
+
+        // This should be done in the frontend
+        (uint256 flashLoanAmount, uint256 effectiveBoldAmount) = _getLeverUpFlashLoanAndBoldAmount(getterParams);
+
+        ILeverageZapper.LeverUpTroveParams memory params = ILeverageZapper.LeverUpTroveParams({
+            troveId: vars.troveId,
+            flashLoanAmount: flashLoanAmount,
+            boldAmount: effectiveBoldAmount,
+            maxUpfrontFee: 1000e18
+        });
+        vm.startPrank(A);
+        // Change receiver in BO
+        contractsArray[_branch].borrowerOperations.setRemoveManagerWithReceiver(
+            vars.troveId, address(_leverageZapper), C
+        );
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        _leverageZapper.leverUpTrove(params);
+        vm.stopPrank();
+    }
+
     function testOnlyFlashLoanProviderCanCallLeverUpCallbackWithCurve() external {
         for (uint256 i = 0; i < NUM_COLLATERALS; i++) {
             _testOnlyFlashLoanProviderCanCallLeverUpCallback(leverageZapperCurveArray[i]);
@@ -777,7 +851,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
             boldAmount: effectiveBoldAmount,
             maxUpfrontFee: 1000e18
         });
-        // B tries to lever up A's trove
+        // B tries to lever up A’s trove
         vm.startPrank(B);
         vm.expectRevert(AddRemoveManagers.NotOwnerNorRemoveManager.selector);
         _leverageZapper.leverUpTrove(params);
@@ -839,7 +913,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         getterParams.branch = _branch;
         (uint256 flashLoanAmount, uint256 effectiveBoldAmount) = _getLeverUpFlashLoanAndBoldAmount(getterParams);
 
-        // B tries to lever up A's trove calling our flash loan provider module
+        // B tries to lever up A’s trove calling our flash loan provider module
         ILeverageZapper.LeverUpTroveParams memory params = ILeverageZapper.LeverUpTroveParams({
             troveId: troveId,
             flashLoanAmount: flashLoanAmount,
@@ -902,7 +976,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         openTroveParams.batchManager = address(0);
         (uint256 troveId,) = openLeveragedTroveWithIndex(openTroveParams);
 
-        // B tries to lever up A's trove calling Balancer Vault directly
+        // B tries to lever up A’s trove calling Balancer Vault directly
         LeverUpParams memory getterParams;
         getterParams.leverageZapper = _leverageZapper;
         getterParams.collToken = contractsArray[_branch].collToken;
@@ -1050,7 +1124,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         // CR
         // When getting flashloan amount, we allow the min debt to deviate up to 5%
         // That deviation can translate into CR, specially for UniV3 exchange which is the less efficient
-        // With UniV3, the quoter gives a price "too good", meaning we exchange less, so the deleverage is lower
+        // With UniV3, the quoter gives a price “too good”, meaning we exchange less, so the deleverage is lower
         uint256 CRTolerance = _exchangeType == ExchangeType.UniV3 ? 9e16 : 17e15;
         uint256 ICR = contractsArray[_branch].troveManager.getCurrentICR(vars.troveId, vars.price);
         assertTrue(
@@ -1085,6 +1159,69 @@ contract ZapperLeverageMainnet is DevTestSetup {
 
         // Check receiver is back to zero
         assertEq(address(_leverageZapper.flashLoanProvider().receiver()), address(0), "Receiver should be zero");
+    }
+
+    function testCannotLeverDownWithCurveFromZapperIfZapperIsNotReceiver() external {
+        for (uint256 i = 0; i < NUM_COLLATERALS; i++) {
+            _testCannotLeverDownFromZapperIfZapperIsNotReceiver(leverageZapperCurveArray[i], ExchangeType.Curve, i);
+        }
+    }
+
+    function testCannotLeverDownWithUniV3FromZapperIfZapperIsNotReceiver() external {
+        for (uint256 i = 0; i < NUM_COLLATERALS; i++) {
+            _testCannotLeverDownFromZapperIfZapperIsNotReceiver(leverageZapperUniV3Array[i], ExchangeType.UniV3, i);
+        }
+    }
+
+    function testCannotLeverDownWithHybridFromZapperIfZapperIsNotReceiver() external {
+        // Not enough liquidity for ETHx
+        for (uint256 i = 0; i < 3; i++) {
+            _testCannotLeverDownFromZapperIfZapperIsNotReceiver(
+                leverageZapperUniV3Array[i], ExchangeType.HybridCurveUniV3, i
+            );
+        }
+    }
+
+    function _testCannotLeverDownFromZapperIfZapperIsNotReceiver(
+        ILeverageZapper _leverageZapper,
+        ExchangeType _exchangeType,
+        uint256 _branch
+    ) internal {
+        // Open trove
+        uint256 collAmount = 10 ether;
+        uint256 leverageRatio = 2e18;
+        OpenLeveragedTroveWithIndexParams memory openTroveParams;
+        openTroveParams.leverageZapper = _leverageZapper;
+        openTroveParams.collToken = contractsArray[_branch].collToken;
+        openTroveParams.index = 0;
+        openTroveParams.collAmount = collAmount;
+        openTroveParams.leverageRatio = leverageRatio;
+        openTroveParams.priceFeed = contractsArray[_branch].priceFeed;
+        openTroveParams.exchangeType = _exchangeType;
+        openTroveParams.branch = _branch;
+        openTroveParams.batchManager = address(0);
+        (uint256 troveId,) = openLeveragedTroveWithIndex(openTroveParams);
+
+        (uint256 flashLoanAmount, uint256 minBoldDebt) = _getLeverDownFlashLoanAndBoldAmount(
+            _leverageZapper,
+            troveId,
+            1.5e18, // _leverageRatio,
+            contractsArray[_branch].troveManager,
+            contractsArray[_branch].priceFeed
+        );
+
+        ILeverageZapper.LeverDownTroveParams memory params = ILeverageZapper.LeverDownTroveParams({
+            troveId: troveId,
+            flashLoanAmount: flashLoanAmount,
+            minBoldAmount: minBoldDebt
+        });
+        vm.startPrank(A);
+        // Change receiver in BO
+        contractsArray[_branch].borrowerOperations.setRemoveManagerWithReceiver(troveId, address(_leverageZapper), C);
+
+        vm.expectRevert("BZ: Zapper is not receiver for this trove");
+        _leverageZapper.leverDownTrove(params);
+        vm.stopPrank();
     }
 
     function testOnlyFlashLoanProviderCanCallLeverDownCallbackWithCurve() external {
@@ -1150,7 +1287,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         openTroveParams.batchManager = address(0);
         (uint256 troveId,) = openLeveragedTroveWithIndex(openTroveParams);
 
-        // B tries to lever up A's trove
+        // B tries to lever up A’s trove
         (uint256 flashLoanAmount, uint256 minBoldDebt) = _getLeverDownFlashLoanAndBoldAmount(
             _leverageZapper,
             troveId,
@@ -1218,7 +1355,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         openTroveParams.batchManager = address(0);
         (uint256 troveId,) = openLeveragedTroveWithIndex(openTroveParams);
 
-        // B tries to lever down A's trove calling our flash loan provider module
+        // B tries to lever down A’s trove calling our flash loan provider module
         (uint256 flashLoanAmount, uint256 minBoldDebt) = _getLeverDownFlashLoanAndBoldAmount(
             _leverageZapper,
             troveId,
@@ -1288,7 +1425,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         openTroveParams.batchManager = address(0);
         (uint256 troveId,) = openLeveragedTroveWithIndex(openTroveParams);
 
-        // B tries to lever down A's trove calling Balancer Vault directly
+        // B tries to lever down A’s trove calling Balancer Vault directly
         (uint256 flashLoanAmount, uint256 minBoldDebt) = _getLeverDownFlashLoanAndBoldAmount(
             _leverageZapper,
             troveId,
@@ -1512,7 +1649,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         bool lst = _branch > 0;
         uint256 troveId = openTrove(_zapper, A, 0, collAmount, boldAmount, lst);
 
-        // B tries to close A's trove
+        // B tries to close A’s trove
         uint256 flashLoanAmount =
             _getCloseFlashLoanAmount(troveId, contractsArray[_branch].troveManager, contractsArray[_branch].priceFeed);
 
@@ -1557,7 +1694,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         bool lst = _branch > 0;
         uint256 troveId = openTrove(_zapper, A, 0, collAmount, boldAmount, lst);
 
-        // B tries to close A's trove calling our flash loan provider module
+        // B tries to close A’s trove calling our flash loan provider module
         uint256 flashLoanAmount =
             _getCloseFlashLoanAmount(troveId, contractsArray[_branch].troveManager, contractsArray[_branch].priceFeed);
 
@@ -1608,7 +1745,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         bool lst = _branch > 0;
         uint256 troveId = openTrove(_zapper, A, 0, collAmount, boldAmount, lst);
 
-        // B tries to close A's trove calling Balancer Vault directly
+        // B tries to close A’s trove calling Balancer Vault directly
         uint256 flashLoanAmount =
             _getCloseFlashLoanAmount(troveId, contractsArray[_branch].troveManager, contractsArray[_branch].priceFeed);
 
@@ -1695,7 +1832,7 @@ contract ZapperLeverageMainnet is DevTestSetup {
         uint256 step = (_maxBoldAmount - _boldAmount) / 5; // In max 5 iterations we should reach the target, unless price is lower
         uint256 dy;
         // TODO: Optimizations: binary search, change the step depending on last dy, ...
-        // Or check if there's any helper implemented anywhere
+        // Or check if there’s any helper implemented anywhere
         uint256 lastBoldAmount = _maxBoldAmount + step;
         do {
             lastBoldAmount -= step;

--- a/contracts/test/zapperWETH.t.sol
+++ b/contracts/test/zapperWETH.t.sol
@@ -27,7 +27,7 @@ contract ZapperWETHTest is DevTestSetup {
         WETH = new WETH9();
 
         TestDeployer.TroveManagerParams[] memory troveManagerParams = new TestDeployer.TroveManagerParams[](1);
-        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e18);
+        troveManagerParams[0] = TestDeployer.TroveManagerParams(150e16, 110e16, 10e16, 110e16, 5e16, 10e16, 10e24);
 
         TestDeployer deployer = new TestDeployer();
         TestDeployer.LiquityContractsDev[] memory contractsArray;


### PR DESCRIPTION
https://github.com/liquity/bold/pull/893/files

zappers may require extra work for our new collateral types, so be aware these will be deployed a bit after the rest of the protocol.