### PR TITLE
fixed borrower operations tests

### DIFF
--- a/contracts/test/TestContracts/Deployment.t.sol
+++ b/contracts/test/TestContracts/Deployment.t.sol
@@ -398,8 +398,8 @@ contract TestDeployer is MetadataDeployment {
             address(this),
             _troveManagerParams.CCR,
             _troveManagerParams.MCR,
-            _troveManagerParams.SCR,
             _troveManagerParams.BCR,
+            _troveManagerParams.SCR,
             _troveManagerParams.debtLimit,
             _troveManagerParams.LIQUIDATION_PENALTY_SP,
             _troveManagerParams.LIQUIDATION_PENALTY_REDISTRIBUTION


### PR DESCRIPTION
updated tests to not use deal(address(boldToken)) instead uses an extra account to transfer bold to pay off troves.