### PR TITLE
Fixed subgraph indexing issues

### DIFF
--- a/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
+++ b/frontend/app/src/screens/LoanScreen/PanelClosePosition.tsx
@@ -146,6 +146,7 @@ export function PanelClosePosition({ loan }: { loan: PositionLoanCommitted }) {
                       </>
                     ),
                   })}
+                  // TODO: Enable repaying with collateral later after testing flashloan swap in Zappers
                   items={(["USND", collToken.symbol] as const).map(
                     (symbol) => ({
                       icon: <TokenIcon symbol={symbol} />,

--- a/frontend/app/src/services/TransactionFlow.tsx
+++ b/frontend/app/src/services/TransactionFlow.tsx
@@ -505,6 +505,12 @@ function useFlowManager(account: Address | null, isSafe: boolean = false) {
           writeContract: getWriteContract(wagmiConfig, account),
         };
 
+        // TODO: An error occurs somewhere here when the flow is openBorrowPosition.
+        // The error is:
+        // Error at step 0: Error:
+        // Invalid response from the subgraph
+        //    at async Object.verify
+
         let artifact = currentArtifact;
 
         if (!artifact) {

--- a/subgraph/src/TroveManager.mapping.ts
+++ b/subgraph/src/TroveManager.mapping.ts
@@ -427,9 +427,21 @@ export function handleTroveUpdated(event: TroveUpdatedEvent): void {
   let troveId = event.params._troveId;
   let timestamp = event.block.timestamp;
   let tm = TroveManagerContract.bind(event.address);
+
+  let troveNft = TroveNFTContract.bind(Address.fromBytes(
+    dataSource.context().getBytes("address:troveNft"),
+  ));
+
+  let trove: Trove
   
-  // Update the trove with latest data, no leverage change and don't create if missing
-  let trove = updateTrove(tm, troveId, timestamp, LeverageUpdate.unchanged, false);
+  let owner = troveNft.try_ownerOf(troveId);
+  if (!(owner.reverted || owner.value === Address.fromString("0x0000000000000000000000000000000000000000"))) {
+    // Update the trove with latest data, no leverage change and don't create if missing
+    trove = updateTrove(tm, troveId, timestamp, LeverageUpdate.unchanged, true);
+  } else {
+    // Update the trove with latest data, no leverage change and don't create if missing
+    trove = updateTrove(tm, troveId, timestamp, LeverageUpdate.unchanged, false);
+  }
   
   // Ensure the trove is active
   trove.status = "active";

--- a/subgraph/src/TroveNFT.mapping.ts
+++ b/subgraph/src/TroveNFT.mapping.ts
@@ -1,4 +1,4 @@
-import { Address, dataSource } from "@graphprotocol/graph-ts";
+import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts";
 import { Trove } from "../generated/schema";
 import { Transfer as TransferEvent } from "../generated/templates/TroveNFT/TroveNFT";
 import { BorrowerTrovesCountUpdate, updateBorrowerTrovesCount } from "./shared";
@@ -19,7 +19,7 @@ export function handleTransfer(event: TransferEvent): void {
     throw new Error("Trove does not exist: " + troveFullId);
   }
 
-  let collIndex = <i32> parseInt(trove.collateral);
+  let collIndex = BigInt.fromString(trove.collateral).toI32();
 
   // update troves count & ownerIndex for the previous owner
   updateBorrowerTrovesCount(


### PR DESCRIPTION
There was a bug in the `handleTroveUpdated` function that threw an error for new troves. Added a check to make sure trove ID exists and then if so, then it creates new trove object in indexer. Else, the trove ID should already exist in indexer and throws error if not found.