### PR TITLE
Fix earn position hooks and rendering

### DIFF
--- a/frontend/app/src/comps/EarnPositionSummary/EarnPositionSummary.tsx
+++ b/frontend/app/src/comps/EarnPositionSummary/EarnPositionSummary.tsx
@@ -15,6 +15,7 @@ import {
 } from "@liquity2/uikit";
 import * as dn from "dnum";
 import Link from "next/link";
+import { dnum18 } from "@/src/dnum-utils";
 
 export function EarnPositionSummary({
   collIndex,
@@ -26,7 +27,7 @@ export function EarnPositionSummary({
 }: {
   collIndex: CollIndex;
   prevEarnPosition?: PositionEarn | null;
-  earnPosition: PositionEarn | null;
+  earnPosition: PositionEarn | null | undefined;
   linkToScreen?: boolean;
   title?: ReactNode;
   txPreviewMode?: boolean;
@@ -34,7 +35,7 @@ export function EarnPositionSummary({
   const collToken = getCollToken(collIndex);
   const earnPool = useEarnPool(collIndex);
 
-  const { totalDeposited: totalPoolDeposit } = earnPool.data;
+  const { totalDeposited: totalPoolDeposit } = earnPool.data ?? { totalDeposited: dnum18(0) };
 
   let share = dn.from(0, 18);
   let prevShare = dn.from(0, 18);
@@ -45,6 +46,8 @@ export function EarnPositionSummary({
     if (prevEarnPosition) {
       prevShare = dn.div(prevEarnPosition.deposit, totalPoolDeposit);
     }
+  } else if (txPreviewMode) {
+    share = dn.from(1, 18);
   }
 
   // true if the user has any deposit

--- a/frontend/app/src/comps/Positions/PositionCardEarn.tsx
+++ b/frontend/app/src/comps/Positions/PositionCardEarn.tsx
@@ -101,7 +101,7 @@ export function PositionCardEarn({
                       <Amount
                         fallback='−'
                         percentage
-                        value={earnPool.data.apr}
+                        value={earnPool.data?.apr}
                       />
                     </div>
                   </div>
@@ -126,7 +126,7 @@ export function PositionCardEarn({
                       <Amount
                         fallback='−'
                         percentage
-                        value={earnPool.data.apr7d}
+                        value={earnPool.data?.apr7d}
                       />
                     </div>
                   </div>

--- a/frontend/app/src/comps/Positions/Positions.tsx
+++ b/frontend/app/src/comps/Positions/Positions.tsx
@@ -7,9 +7,10 @@ import { ACCOUNT_POSITIONS } from "@/src/demo-mode";
 import { DEMO_MODE } from "@/src/env";
 // import { useStakePosition } from "@/src/liquity-utils";
 import {
-  useEarnPositionsByAccount,
+  // useEarnPositionsByAccount,
   useLoansByAccount,
 } from "@/src/subgraph-hooks";
+import { useEarnPositionsByAccount } from "@/src/liquity-utils";
 import { css } from "@/styled-system/css";
 import { a, useSpring, useTransition } from "@react-spring/web";
 // import * as dn from "dnum";
@@ -58,7 +59,10 @@ export function Positions({
     ? ACCOUNT_POSITIONS
     : [
         ...(loans.data ?? []),
-        ...(earnPositions.data ?? []),
+        ...(earnPositions.data?.filter(pos => pos.collIndex !== null).map(pos => ({
+          ...pos,
+          collIndex: pos.collIndex!
+        })) ?? []),
         // ...(stakePosition.data && dn.gt(stakePosition.data.deposit, 0)
         //   ? [stakePosition.data]
         //   : []),

--- a/frontend/app/src/screens/EarnPoolScreen/EarnPoolScreen.tsx
+++ b/frontend/app/src/screens/EarnPoolScreen/EarnPoolScreen.tsx
@@ -169,7 +169,7 @@ export function EarnPoolScreen() {
                 {tab.action === "deposit" && (
                   <PanelUpdateDeposit
                     collIndex={collIndex}
-                    deposited={earnPool.data.totalDeposited ?? dn.from(0, 18)}
+                    deposited={earnPool.data?.totalDeposited ?? dn.from(0, 18)}
                     position={earnPosition.data ?? undefined}
                   />
                 )}

--- a/frontend/app/src/screens/HomeScreen/HomeScreen.tsx
+++ b/frontend/app/src/screens/HomeScreen/HomeScreen.tsx
@@ -203,10 +203,10 @@ function EarnRewardsRow({ symbol }: { symbol: CollateralSymbol }) {
         </div>
       </td>
       <td>
-        <Amount fallback='…' percentage value={earnPool.data.apr} />
+        <Amount fallback='…' percentage value={earnPool.data?.apr} />
       </td>
       <td>
-        <Amount fallback='…' percentage value={earnPool.data.apr7d} />
+        <Amount fallback='…' percentage value={earnPool.data?.apr7d} />
       </td>
       <td>
         <Amount

--- a/frontend/app/src/subgraph-hooks.ts
+++ b/frontend/app/src/subgraph-hooks.ts
@@ -7,15 +7,14 @@ import type { Address, CollIndex, Delegate, PositionEarn, PositionLoanCommitted,
 
 import { DATA_REFRESH_INTERVAL } from "@/src/constants";
 import { ACCOUNT_POSITIONS } from "@/src/demo-mode";
-import { dnum18, jsonStringifyWithDnum } from "@/src/dnum-utils";
-import { COLLATERAL_CONTRACTS, DEMO_MODE } from "@/src/env";
+import { dnum18 } from "@/src/dnum-utils";
+import { DEMO_MODE } from "@/src/env";
 import { isCollIndex, isPositionLoanCommitted, isPrefixedtroveId, isTroveId } from "@/src/types";
 import { sleep } from "@/src/utils";
 import { isAddress, shortenAddress } from "@liquity2/uikit";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import * as dn from "dnum";
 import { useCallback } from "react";
-import { useReadContracts, useConfig as useWagmiConfig } from "wagmi";
 import {
   AllInterestRateBracketsQuery,
   BorrowerInfoQuery,
@@ -32,9 +31,6 @@ import {
   TroveByIdQuery,
   TrovesByAccountQuery,
 } from "./subgraph-queries";
-import { getCollIndexFromSymbol, getCollToken, useLiquityStats } from "./liquity-utils";
-import { readContract, readContracts } from "wagmi/actions";
-import { getCollateralContract } from "./contracts";
 
 type Options = {
   refetchInterval?: number;
@@ -375,153 +371,6 @@ export function useStabilityPoolScale(
     queryKey: ["StabilityPoolScale", collIndex, String(scale)],
     queryFn,
     ...prepareOptions(options),
-  });
-}
-
-export function useEarnPool(collIndex: CollIndex | null) {
-  const wagmiConfig = useWagmiConfig();
-  const stats = useLiquityStats();
-  const collateral = getCollToken(collIndex);
-  const { spApyAvg1d = null, spApyAvg7d = null } = (
-    collateral && stats.data?.branch[collateral?.symbol]
-  ) ?? {};
-
-  return useQuery({
-    queryKey: [
-      "earnPool",
-      collIndex,
-      jsonStringifyWithDnum(spApyAvg1d),
-      jsonStringifyWithDnum(spApyAvg7d),
-    ],
-    queryFn: async () => {
-      if (collIndex === null) {
-        return null;
-      }
-      const spContract = getCollateralContract(collIndex, "StabilityPool");
-      if (!spContract) {
-        return null;
-      }
-      const totalBoldDeposits = await readContract(wagmiConfig, {
-        ...spContract,
-        functionName: "getTotalBoldDeposits",
-      });
-      return {
-        apr: spApyAvg1d,
-        apr7d: spApyAvg7d,
-        collateral,
-        totalDeposited: dnum18(totalBoldDeposits),
-      };
-    },
-    enabled: stats.isSuccess,
-  });
-}
-
-export function isEarnPositionActive(position: PositionEarn | null) {
-  return Boolean(
-    position && (
-      dn.gt(position.deposit, 0)
-      || dn.gt(position.rewards.usnd, 0)
-      || dn.gt(position.rewards.coll, 0)
-    ),
-  );
-}
-
-function earnPositionsContractsReadSetup(collIndex: CollIndex, account: Address | null) {
-  const StabilityPool = getCollateralContract(collIndex, "StabilityPool");
-  return {
-    contracts: [
-      {
-        ...StabilityPool,
-        functionName: "getCompoundedBoldDeposit",
-        args: [account ?? "0x"],
-      }, 
-      {
-        ...StabilityPool,
-        functionName: "getDepositorCollGain",
-        args: [account ?? "0x"],
-      }, 
-      {
-        ...StabilityPool,
-        functionName: "stashedColl",
-        args: [account ?? "0x"],
-      }, 
-      {
-        ...StabilityPool,
-        functionName: "getDepositorYieldGainWithPending",
-        args: [account ?? "0x"],
-      }
-    ],
-    select: ([
-      deposit,
-      collGain,
-      stashedColl,
-      yieldGainWithPending,
-    ]: [
-      bigint,
-      bigint,
-      bigint,
-      bigint,
-    ]) => {
-      if (!account) {
-        throw new Error(); // should never happen (see enabled)
-      }
-      return deposit === 0n ? null : {
-        type: "earn",
-        owner: account,
-        deposit: dnum18(deposit),
-        collIndex,
-        rewards: {
-          usnd: dnum18(yieldGainWithPending),
-          coll: dn.add(
-            dnum18(collGain),
-            dnum18(stashedColl),
-          ),
-        },
-      } as const;
-    },
-  } as const;
-}
-
-export function useEarnPosition(
-  collIndex: CollIndex,
-  account: null | Address,
-): UseQueryResult<PositionEarn | null> {
-  const setup = earnPositionsContractsReadSetup(collIndex, account);
-  return useReadContracts({
-    contracts: setup.contracts,
-    allowFailure: false,
-    query: {
-      enabled: Boolean(account),
-      select: setup.select as any,
-    },
-  }) as any;
-}
-
-export function useEarnPositionsByAccount(account: null | Address) {
-  const wagmiConfig = useWagmiConfig();
-  return useQuery({
-    queryKey: ["StabilityPoolDepositsByAccount", account],
-    queryFn: async () => {
-      if (!account) {
-        return null;
-      }
-
-      const branches = COLLATERAL_CONTRACTS;
-
-      const depositsPerBranch = await Promise.all(
-        branches.map(async (branch) => {
-          const i = getCollIndexFromSymbol(branch.symbol);
-          const setup = earnPositionsContractsReadSetup(i!, account);
-          const deposits = await readContracts(wagmiConfig, {
-            contracts: setup.contracts as any,
-            allowFailure: false,
-          });
-          return setup.select(deposits as any);
-        }),
-      );
-
-      return depositsPerBranch.filter((position) => position !== null);
-    },
   });
 }
 


### PR DESCRIPTION
Replaced subgraph queries with contract read calls in the `useEarnPosition` and related hooks. Now earn position and previews display properly in UI.

*NOTE: The APYs are not present. Liquity hosts an API endpoint for sharing a JSON of that information. We will need to look into doing the same.*

This is related to issue #174 as a workaround rather than an actual fix to the subgraph indexing of stability pool events.