### PR TITLE
[CONT] Add stats to footer with tweaks

### DIFF
--- a/frontend/app/src/comps/ProtocolStats/ProtocolStats.tsx
+++ b/frontend/app/src/comps/ProtocolStats/ProtocolStats.tsx
@@ -5,8 +5,8 @@ import type { TokenSymbol } from "@/src/types";
 import { Amount } from "@/src/comps/Amount/Amount";
 import { Logo } from "@/src/comps/Logo/Logo";
 import { ACCOUNT_SCREEN } from "@/src/env";
-import { useLiquityStats } from "@/src/liquity-utils";
 import { useAccount } from "@/src/services/Arbitrum";
+import { useLandingPageStats } from "@/src/services/LandingPageStats";
 import { usePrice } from "@/src/services/Prices";
 import { css } from "@/styled-system/css";
 import {
@@ -26,9 +26,7 @@ const DISPLAYED_PRICES = ["USND", "ETH"] as const;
 
 export function ProtocolStats() {
   const account = useAccount();
-  const stats = useLiquityStats();
-
-  const tvl = stats.data?.totalValueLocked;
+  const landingStats = useLandingPageStats();
 
   return (
     <div
@@ -48,16 +46,48 @@ export function ProtocolStats() {
           userSelect: "none",
         })}
       >
-        <HFlex gap={4} alignItems='center'>
-          <Logo />
-          {tvl && (
-            <>
-              <span>TVL</span>{" "}
-              <span>
-                <Amount fallback='…' format='compact' prefix='$' value={tvl} />
-              </span>
-            </>
-          )}
+        <HFlex gap={16} alignItems='center'>
+          <HFlex gap={4} alignItems='center'>
+            <Logo />
+            <span>TVL</span>{" "}
+            <span>
+              {landingStats.isLoading ? '…' : 
+              landingStats.error ? 'Error' :
+              landingStats.tvl ? (
+                <Amount fallback='…' format='compact' prefix='$' value={landingStats.tvl} />
+              ) : '…'}
+            </span>
+          </HFlex>
+          <HFlex gap={4} alignItems='center'>
+            <span>SP APR</span>{" "}
+            <span>
+              {landingStats.stabilityPoolAPR ? (
+                <Amount fallback='…' format='2z' suffix='%' value={[BigInt(Math.round(landingStats.stabilityPoolAPR * 100 * 1e18)), 18]} />
+              ) : (
+                '…'
+              )}
+            </span>
+          </HFlex>
+          <HFlex gap={4} alignItems='center'>
+            <span>Vaults</span>{" "}
+            <span>
+              {landingStats.vaultCount ? (
+                landingStats.vaultCount.toLocaleString()
+              ) : (
+                '…'
+              )}
+            </span>
+          </HFlex>
+          <HFlex gap={4} alignItems='center'>
+            <span>Go Slow NFTs</span>{" "}
+            <span>
+              {landingStats.isLoading ? '...' : 
+              landingStats.error ? 'Error' :
+              landingStats.goSlowNFTCount !== null ? (
+                landingStats.goSlowNFTCount.toLocaleString()
+              ) : '...'}
+            </span>
+          </HFlex>
         </HFlex>
         <HFlex gap={16}>
           {DISPLAYED_PRICES.map((symbol) => (

--- a/frontend/app/src/comps/ProtocolStats/ProtocolStats.tsx
+++ b/frontend/app/src/comps/ProtocolStats/ProtocolStats.tsx
@@ -21,6 +21,7 @@ import {
 import { blo } from "blo";
 import Image from "next/image";
 import Link from "next/link";
+import * as dn from "dnum";
 
 const DISPLAYED_PRICES = ["USND", "ETH"] as const;
 
@@ -62,13 +63,14 @@ export function ProtocolStats() {
             <span>SP APR</span>{" "}
             <span>
               {landingStats.stabilityPoolAPR ? (
-                <Amount fallback='…' format='2z' suffix='%' value={[BigInt(Math.round(landingStats.stabilityPoolAPR * 100 * 1e18)), 18]} />
+                // <Amount fallback='…' format='2z' suffix='%' value={[BigInt(Math.round(landingStats.stabilityPoolAPR * 100 * 1e18)), 18]} />
+                <Amount fallback='…' format='2z' suffix='%' value={dn.mul(landingStats.stabilityPoolAPR, 100)} />
               ) : (
                 '…'
               )}
             </span>
           </HFlex>
-          <HFlex gap={4} alignItems='center'>
+          {/* <HFlex gap={4} alignItems='center'>
             <span>Vaults</span>{" "}
             <span>
               {landingStats.vaultCount ? (
@@ -77,17 +79,16 @@ export function ProtocolStats() {
                 '…'
               )}
             </span>
-          </HFlex>
-          <HFlex gap={4} alignItems='center'>
+          </HFlex> */}
+          {/* <HFlex gap={4} alignItems='center'>
             <span>Go Slow NFTs</span>{" "}
             <span>
               {landingStats.isLoading ? '...' : 
-              landingStats.error ? 'Error' :
               landingStats.goSlowNFTCount !== null ? (
                 landingStats.goSlowNFTCount.toLocaleString()
               ) : '...'}
             </span>
-          </HFlex>
+          </HFlex> */}
         </HFlex>
         <HFlex gap={16}>
           {DISPLAYED_PRICES.map((symbol) => (

--- a/frontend/app/src/services/LandingPageStats.ts
+++ b/frontend/app/src/services/LandingPageStats.ts
@@ -1,0 +1,157 @@
+import { DATA_REFRESH_INTERVAL } from "@/src/constants";
+import { useLiquityStats } from "@/src/liquity-utils";
+import { useTroveCount } from "@/src/subgraph-hooks";
+import { DEMO_MODE, CHAIN_ID } from "@/src/env";
+import { useQuery } from "@tanstack/react-query";
+import { useReadContract } from "wagmi";
+import { getAddress } from "viem";
+import * as v from "valibot";
+
+// Constants
+const ARBITRUM_CHAIN_ID = 42161;
+const GO_SLOW_NFT_CONTRACT_ADDRESS = "0x6da3c02293c96dfa5747b1739ebb492619222a8a";
+
+// DefiLlama API schema for TVL data
+const DefiLlamaSchema = v.object({
+  tvl: v.number(),
+  tokensInUsd: v.optional(v.record(v.string(), v.number())),
+});
+
+// Stability Pool APR calculation
+export function useStabilityPoolAPR() {
+  const stats = useLiquityStats();
+  
+  if (!stats.data?.branch) {
+    return {
+      data: null,
+      isLoading: stats.isLoading,
+      error: stats.error,
+    };
+  }
+
+  let totalTvl = 0;
+  let weightedAprSum = 0;
+
+  for (const branch of Object.values(stats.data.branch)) {
+    const aprValue = branch.spApyAvg7d?.[0];
+    const branchTvl = Number(branch.valueLocked || 0);
+    
+    if (typeof aprValue === 'bigint') {
+      weightedAprSum += Number(aprValue) * branchTvl;
+      totalTvl += branchTvl;
+    } else if (aprValue) {
+      weightedAprSum += aprValue * branchTvl;
+      totalTvl += branchTvl;
+    }
+  }
+
+  const avgAPR = totalTvl > 0 ? weightedAprSum / totalTvl : null;
+
+  return {
+    data: avgAPR,
+    isLoading: stats.isLoading,
+    error: stats.error,
+  };
+}
+
+// DefiLlama TVL data
+export function useDefiLlamaTVL() {
+  return useQuery({
+    queryKey: ["defillama-tvl"],
+    queryFn: async () => {
+      const response = await fetch("https://api.llama.fi/protocol/nerite");
+      if (!response.ok) {
+        throw new Error("Failed to fetch DefiLlama TVL data");
+      }
+      const data = await response.json();
+      return v.parse(DefiLlamaSchema, data);
+    },
+    refetchInterval: DATA_REFRESH_INTERVAL,
+    enabled: true,
+  });
+}
+
+// Number of vaults (total count of active troves from subgraph)
+export function useVaultCount() {
+  const troveCount = useTroveCount();
+
+  return {
+    data: troveCount.data,
+    isLoading: troveCount.isLoading,
+    error: troveCount.error,
+  };
+}
+
+// Go Slow NFT minted count (ERC-1155 on Arbitrum)
+export function useGoSlowNFTCount() {
+  // Check if calling Arbitrum contract from different chain
+  const isChainMismatch = CHAIN_ID !== ARBITRUM_CHAIN_ID;
+  
+  const contractAddress = getAddress(GO_SLOW_NFT_CONTRACT_ADDRESS);
+  
+  const result = useReadContract({
+    address: contractAddress,
+    abi: [
+      {
+        inputs: [],
+        name: "numMinted",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+      }
+    ] as const,
+    functionName: "numMinted",
+    chainId: ARBITRUM_CHAIN_ID,
+    query: {
+      refetchInterval: DATA_REFRESH_INTERVAL,
+      enabled: !isChainMismatch, // Try to get real data even in demo mode
+      retry: 1,
+    },
+  });
+
+  // Handle chain mismatch - but still try to get real data in demo mode
+  if (isChainMismatch) {
+    // In demo mode, show a demo value when we can't access the real chain
+    if (DEMO_MODE) {
+      return {
+        data: 1337, // Demo NFT count when chain mismatch prevents real data
+        isLoading: false,
+        error: null,
+      };
+    }
+    
+    return {
+      data: null,
+      isLoading: false,
+      error: new Error(`Go Slow NFT is on Arbitrum (${ARBITRUM_CHAIN_ID}) but app is configured for chain ${CHAIN_ID}`),
+    };
+  }
+
+  return {
+    data: result.data ? Number(result.data) : null,
+    isLoading: result.isLoading,
+    error: result.error,
+  };
+}
+
+// Combined hook for all landing page statistics
+export function useLandingPageStats() {
+  const stabilityPoolAPR = useStabilityPoolAPR();
+  const defiLlamaTVL = useDefiLlamaTVL();
+  const vaultCount = useVaultCount();
+  const goSlowNFTCount = useGoSlowNFTCount();
+
+  // In demo mode, ignore certain errors since we use mock data
+  const relevantError = DEMO_MODE 
+    ? null // Ignore all errors in demo mode since we have fallback data
+    : (stabilityPoolAPR.error || defiLlamaTVL.error || vaultCount.error || goSlowNFTCount.error);
+
+  return {
+    stabilityPoolAPR: stabilityPoolAPR.data,
+    tvl: defiLlamaTVL.data?.tvl,
+    vaultCount: vaultCount.data,
+    goSlowNFTCount: goSlowNFTCount.data,
+    isLoading: stabilityPoolAPR.isLoading || defiLlamaTVL.isLoading || vaultCount.isLoading || goSlowNFTCount.isLoading,
+    error: relevantError,
+  };
+}

--- a/frontend/app/src/subgraph-queries.ts
+++ b/frontend/app/src/subgraph-queries.ts
@@ -296,3 +296,4 @@ export const GovernanceUserAllocated = graphql(`
     }
   }
 `);
+


### PR DESCRIPTION
This is a continuation of PR #180. Made some tweaks and fixes.

We don't need all of these stats in the app footer but I did keep the APR displayed. Number of troves and Go Slow NFTs minted are for the [landing page website](https://www.nerite.org/). May display them in the future though in the app so decided not to remove the hooks for them.

Shout out to @richardgreg for the contribution. Much appreciated.