### PR TITLE
Backup read calls in case of subgraph query failures

### DIFF
--- a/frontend/app/src/app/layout.tsx
+++ b/frontend/app/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { TransactionFlow } from "@/src/services/TransactionFlow";
 import { UiKit } from "@liquity2/uikit";
 import { Analytics } from "@vercel/analytics/react";
 import { GeistSans } from "geist/font/sans";
+import { SubgraphStatus } from "../services/SubgraphStatus";
 
 export const metadata: Metadata = {
   title: content.appName,
@@ -31,11 +32,13 @@ export default function Layout({ children }: { children: ReactNode }) {
             <StoredState>
               <DemoMode>
                 <Arbitrum>
-                  <Blocking>
-                    <TransactionFlow>
-                      <AppLayout>{children}</AppLayout>
-                    </TransactionFlow>
-                  </Blocking>
+                  <SubgraphStatus>
+                    <Blocking>
+                      <TransactionFlow>
+                        <AppLayout>{children}</AppLayout>
+                      </TransactionFlow>
+                    </Blocking>
+                  </SubgraphStatus>
                 </Arbitrum>
               </DemoMode>
             </StoredState>

--- a/frontend/app/src/comps/AppLayout/AppLayout.tsx
+++ b/frontend/app/src/comps/AppLayout/AppLayout.tsx
@@ -6,11 +6,14 @@ import { Banner } from "@/Banner";
 import { ProtocolStats } from "@/src/comps/ProtocolStats/ProtocolStats";
 import { TopBar } from "@/src/comps/TopBar/TopBar";
 import { css } from "@/styled-system/css";
+import { useSubgraphStatus } from "@/src/services/SubgraphStatus";
+import { ErrorBanner } from "@/src/comps/ErrorBanner/ErrorBanner";
 
 export const LAYOUT_WIDTH = 1092;
 export const MIN_WIDTH = 960;
 
 export function AppLayout({ children }: { children: ReactNode }) {
+  const { hasError } = useSubgraphStatus();
   return (
     <>
       <Banner />
@@ -38,6 +41,17 @@ export function AppLayout({ children }: { children: ReactNode }) {
           })}
         >
           <TopBar />
+          {hasError && (
+            <ErrorBanner
+              title="We are experiencing connection issues with the subgraph at the moment. Your positions are not affected."
+              children={
+                <div>
+                  <p>Some actions in the app may be degraded or unavailable in the meantime. Thank you for your patience as we resolve the issue.</p>
+                  <p>If you have any questions, please contact us on <a className={css({ color: "primary", textDecoration: "underline" })} target="_blank" href="https://discord.gg/5h3avBYxcn">Discord</a> or <a className={css({ color: "primary", textDecoration: "underline" })} target="_blank" href="https://x.com/neriteorg">X</a>.</p>
+                </div>
+              }
+            />
+          )}
         </div>
         <div
           className={css({

--- a/frontend/app/src/comps/ErrorBanner/ErrorBanner.tsx
+++ b/frontend/app/src/comps/ErrorBanner/ErrorBanner.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+
+import { css } from "@/styled-system/css";
+import { useElementSize } from "@liquity2/uikit";
+import { a, useSpring } from "@react-spring/web";
+import { useRef } from "react";
+
+export function ErrorBanner({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  const expanded = true
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { size } = useElementSize(contentRef);
+
+  const contentStyles = useSpring({
+    opacity: 1,
+    height: expanded ? (size?.blockSize ?? 0) + 32 : 0,
+    chevronTransform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+    config: {
+      mass: 1,
+      tension: 1800,
+      friction: 80,
+      clamp: true,
+    },
+  });
+
+  return (
+    <section
+      className={css({
+        width: "100%",
+        background: "negativeSurface",
+        color: "negative",
+        fontSize: 14,
+        border: "1px solid token(colors.negativeSurfaceBorder)",
+        borderRadius: 8,
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: "100%",
+          height: 46, // 48 - border width
+          padding: "0 0 0 24px",
+          borderRadius: 8,
+          _focusVisible: {
+            outline: "2px solid token(colors.focused)",
+          },
+        })}
+      >
+        <h1
+          className={css({
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          })}
+        >
+          {title}
+        </h1>
+      </div>
+      <a.div
+        style={{
+          overflow: "hidden",
+          willChange: "height",
+          ...contentStyles,
+        }}
+      >
+        <div
+          ref={contentRef}
+          className={css({
+            padding: "8px 24px 24px",
+            color: "negativeSurfaceContent",
+            overflow: "auto",
+            _focusVisible: {
+              outline: "2px solid token(colors.focused)",
+            },
+          })}
+        >
+          {children}
+        </div>
+      </a.div>
+    </section>
+  );
+}

--- a/frontend/app/src/liquity-read-calls.ts
+++ b/frontend/app/src/liquity-read-calls.ts
@@ -1,9 +1,9 @@
-import { Address, createPublicClient, http, toHex } from "viem";
+import { Address, createPublicClient, hexToBigInt, http, toHex } from "viem";
 import { getContracts } from "./contracts";
-import { CollIndex, CombinedTroveData, DebtPerInterestRate, ReturnTroveReadCallData, Trove, TroveStatus } from "./types";
+import { CollIndex, CombinedTroveData, DebtPerInterestRate, PrefixedTroveId, ReturnCombinedTroveReadCallData, ReturnTroveReadCallData, Trove, TroveStatus } from "./types";
 import { CHAIN_RPC_URL } from "./env";
 import { CHAIN } from "./services/Arbitrum";
-import { getCollToken, getPrefixedTroveId } from "./liquity-utils";
+import { getCollToken, getPrefixedTroveId, parsePrefixedTroveId } from "./liquity-utils";
 
 export function getPublicClient() {
   return createPublicClient({
@@ -43,7 +43,66 @@ export async function getAllTroves(): Promise<Record<CollIndex, CombinedTroveDat
   return troves;
 }
 
-export async function getTrovesByAccount(account: Address): Promise<ReturnTroveReadCallData[]> {
+export async function getTroveById(id: PrefixedTroveId): Promise<ReturnTroveReadCallData | undefined> {
+  const { collaterals } = getContracts()
+  const client = getPublicClient()
+  const { collIndex, troveId } = parsePrefixedTroveId(id)
+  const tokenId = hexToBigInt(troveId)
+  const output = await client.multicall({
+    contracts: [
+      {
+        ...collaterals[collIndex]!.contracts.TroveNFT,
+        functionName: "ownerOf",
+        args: [tokenId],
+      },
+      {
+        ...collaterals[collIndex]!.contracts.TroveManager,
+        functionName: "Troves",
+        args: [tokenId],
+      }
+    ]
+  })
+
+  const collateral = getCollToken(collIndex)!
+  const trove = output[1]?.result ? {
+    debt: output[1]?.result[0],
+    coll: output[1]?.result[1],
+    stake: output[1]?.result[2],
+    status: output[1]?.result[3],
+    arrayIndex: output[1]?.result[4],
+    lastDebtUpdateTime: output[1]?.result[5],
+    lastInterestRateAdjTime: output[1]?.result[6],
+    annualInterestRate: output[1]?.result[7],
+    interestBatchManager: output[1]?.result[8],
+    batchDebtShares: output[1]?.result[9],
+  } as Trove : undefined
+  const owner = output[0]?.result as Address
+  if (!owner || !trove) return undefined
+
+  return {
+    ...trove,
+    id,
+    troveId,
+    borrower: owner,
+    deposit: trove.coll,
+    interestRate: trove.annualInterestRate,
+    collateral: {
+      id: collIndex.toString(),
+      token: {
+        symbol: collateral.symbol,
+        name: collateral.name,
+      },
+      minCollRatio: collateral.collateralRatio,
+      collIndex,
+    },
+    interestBatch: {
+      annualInterestRate: trove.annualInterestRate,
+      batchManager: trove.interestBatchManager,
+    }
+  }
+}
+
+export async function getTrovesByAccount(account: Address): Promise<ReturnCombinedTroveReadCallData[]> {
   const { collaterals } = getContracts()
   const client = getPublicClient()
 

--- a/frontend/app/src/liquity-read-calls.ts
+++ b/frontend/app/src/liquity-read-calls.ts
@@ -1,0 +1,135 @@
+import { Address, createPublicClient, http, toHex } from "viem";
+import { getContracts } from "./contracts";
+import { CollIndex, CombinedTroveData, DebtPerInterestRate, ReturnTroveReadCallData, Trove, TroveStatus } from "./types";
+import { CHAIN_RPC_URL } from "./env";
+import { CHAIN } from "./services/Arbitrum";
+import { getCollToken, getPrefixedTroveId } from "./liquity-utils";
+
+export function getPublicClient() {
+  return createPublicClient({
+    chain: CHAIN,
+    transport: http(CHAIN_RPC_URL),
+  })
+}
+
+export async function getAllTroves(): Promise<Record<CollIndex, CombinedTroveData[]>> {
+  const { collaterals, MultiTroveGetter } = getContracts()
+  const client = getPublicClient()
+  const troves: Record<CollIndex, CombinedTroveData[]> = {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+  }
+
+  const output = await client.multicall({
+    contracts: collaterals.map(collateral => ({
+      ...MultiTroveGetter,
+      functionName: "getMultipleSortedTroves",
+      args: [collateral.collIndex, 0n, 1_000_000_000n],
+    })),
+  })
+
+  output.forEach((troveList, index) => {
+    if (troveList.status === "success") {
+      troves[index as CollIndex] = troveList.result as unknown as CombinedTroveData[];
+    }
+  })
+
+  return troves;
+}
+
+export async function getTrovesByAccount(account: Address): Promise<ReturnTroveReadCallData[]> {
+  const { collaterals } = getContracts()
+  const client = getPublicClient()
+
+  const allTroves = Object.entries(await getAllTroves()).flatMap(([collIndex, troves]) => {
+    return troves.map(trove => ({
+      ...trove,
+      collateral: collaterals[Number(collIndex) as CollIndex]!,
+    }))
+  })
+
+  const troveOwners = await client.multicall({
+    contracts: allTroves.map(trove => [
+      {
+        ...trove.collateral.contracts.TroveNFT,
+        functionName: "ownerOf",
+        args: [trove.id],
+      },
+      {
+        ...trove.collateral.contracts.TroveManager,
+        functionName: "Troves",
+        args: [trove.id],
+      }
+    ]).flat(),
+  })
+
+  const owners = troveOwners.filter((_, index) => index % 2 === 0).map(owner => owner.result as string | undefined)
+  const troves = troveOwners.filter((_, index) => index % 2 === 1).map(trove => trove.result as unknown as Trove | undefined)
+
+  return allTroves
+    .filter((_, index) => owners[index]?.toLowerCase() === account.toLowerCase())
+    .map((trove, index) => {
+      const collateral = getCollToken(trove.collateral.collIndex)!
+      const troveId = toHex(trove.id, { size: 32 })
+      return {
+        ...trove,
+        id: getPrefixedTroveId(trove.collateral.collIndex, troveId),
+        troveId,
+        borrower: owners[index] as Address,
+        debt: trove.entireDebt,
+        deposit: trove.entireColl,
+        interestRate: trove.annualInterestRate,
+        status: troves[index]?.status ?? TroveStatus.nonExistent,
+        collateral: {
+          id: trove.collateral.collIndex.toString(),
+          token: {
+            symbol: collateral.symbol,
+            name: collateral.name,
+          },
+          minCollRatio: collateral.collateralRatio,
+          collIndex: trove.collateral.collIndex,
+        },
+        interestBatch: {
+          annualInterestRate: trove.annualInterestRate,
+          batchManager: trove.interestBatchManager,
+        }
+      }
+    })
+}
+
+export async function getAllDebtPerInterestRate(): Promise<Record<CollIndex, DebtPerInterestRate[]>> {
+  const { collaterals, MultiTroveGetter } = getContracts()
+  const client = getPublicClient()
+  const debtPerInterestRate: Record<CollIndex, DebtPerInterestRate[]> = {
+    0: [],
+    1: [],
+    2: [],
+    3: [],
+    4: [],
+    5: [],
+    6: [],
+    7: [],
+  }
+
+  const output = await client.multicall({
+    contracts: collaterals.map(collateral => ({
+      ...MultiTroveGetter,
+      functionName: "getDebtPerInterestRateAscending",
+      args: [collateral.collIndex, 0n, 1_000_000_000n],
+    })),
+  })
+
+  output.forEach((list, index) => {
+    if (list.status === "success") {
+      debtPerInterestRate[index as CollIndex] = list.result as unknown as DebtPerInterestRate[];
+    }
+  })
+
+  return debtPerInterestRate;
+}

--- a/frontend/app/src/liquity-read-calls.ts
+++ b/frontend/app/src/liquity-read-calls.ts
@@ -180,13 +180,13 @@ export async function getAllDebtPerInterestRate(): Promise<Record<CollIndex, Deb
     contracts: collaterals.map(collateral => ({
       ...MultiTroveGetter,
       functionName: "getDebtPerInterestRateAscending",
-      args: [collateral.collIndex, 0n, 1_000_000_000n],
+      args: [collateral.collIndex, 0n, 10n],
     })),
   })
 
   output.forEach((list, index) => {
     if (list.status === "success") {
-      debtPerInterestRate[index as CollIndex] = list.result as unknown as DebtPerInterestRate[];
+      debtPerInterestRate[index as CollIndex] = (list.result as unknown as [DebtPerInterestRate[], bigint])[0];
     }
   })
 

--- a/frontend/app/src/services/Arbitrum.tsx
+++ b/frontend/app/src/services/Arbitrum.tsx
@@ -84,6 +84,8 @@ const arbitrumChain: Chain = {
   },
 };
 
+export const CHAIN = arbitrumChain;
+
 export function Arbitrum({ children }: { children: ReactNode }) {
   const wagmiConfig = useWagmiConfig();
   const rainbowKitProps = useRainbowKitProps();

--- a/frontend/app/src/services/LandingPageStats.ts
+++ b/frontend/app/src/services/LandingPageStats.ts
@@ -151,21 +151,25 @@ export function useLandingPageStats() {
   const stats = useLiquityStats();
   const stabilityPoolAPR = useStabilityPoolAPR();
   // const defiLlamaTVL = useDefiLlamaTVL();
-  const vaultCount = useVaultCount();
+  // const vaultCount = useVaultCount();
   const goSlowNFTCount = useGoSlowNFTCount();
 
   // In demo mode, ignore certain errors since we use mock data
   const relevantError = DEMO_MODE 
     ? null // Ignore all errors in demo mode since we have fallback data
-    : (stabilityPoolAPR.error || vaultCount.error || goSlowNFTCount.error);
+    : (
+      stabilityPoolAPR.error || 
+      // vaultCount.error || 
+      goSlowNFTCount.error
+    );
 
   return {
     stabilityPoolAPR: stabilityPoolAPR.data,
     // tvl: defiLlamaTVL.data?.tvl,
     tvl: stats.data?.totalValueLocked,
-    vaultCount: vaultCount.data,
+    // vaultCount: vaultCount.data,
     goSlowNFTCount: goSlowNFTCount.data,
-    isLoading: stabilityPoolAPR.isLoading || vaultCount.isLoading || goSlowNFTCount.isLoading,
+    isLoading: stabilityPoolAPR.isLoading || goSlowNFTCount.isLoading,
     error: relevantError,
   };
 }

--- a/frontend/app/src/services/SubgraphStatus.tsx
+++ b/frontend/app/src/services/SubgraphStatus.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
+
+type SubgraphStatus = {
+  hasError: boolean;
+  errors: { id: string, error: Error }[];
+  setError: (id: string, error: Error) => void;
+  clearError: (id: string) => void;
+  clearAllErrors: () => void;
+};
+
+const SubgraphErrorContext = createContext<SubgraphStatus | undefined>(undefined);
+
+export const SubgraphStatusProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [errors, setErrorState] = useState<{ id: string, error: Error }[]>([]);
+
+  const setError = useCallback((id: string, err: Error) => {
+    const existingError = errors.find(e => e.id === id);
+    if (existingError) {
+      setErrorState(errors.map(e => e.id === id ? { ...e, error: err } : e));
+    } else {
+      setErrorState([...errors, { id, error: err }]);
+    }
+  }, []);
+
+  const clearError = useCallback((id: string) => {
+    const exists = errors.find(e => e.id === id);
+    if (exists) {
+      setErrorState(errors.filter(e => e.id !== id));
+    }
+  }, []);
+
+  const clearAllErrors = useCallback(() => {
+    setErrorState([]);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      hasError: errors.length > 0,
+      errors,
+      setError,
+      clearError,
+      clearAllErrors,
+    }),
+    [errors, setError, clearError, clearAllErrors]
+  );
+
+  return (
+    <SubgraphErrorContext.Provider value={value}>
+      {children}
+    </SubgraphErrorContext.Provider>
+  );
+};
+
+export function SubgraphStatus({ children }: { children: React.ReactNode }) {
+  return (
+    <SubgraphStatusProvider>
+      {children}
+    </SubgraphStatusProvider>
+  );
+}
+
+export function useSubgraphStatus() {
+  const context = useContext(SubgraphErrorContext);
+  if (context === undefined) {
+    throw new Error("useSubgraphErrorState must be used within a SubgraphErrorProvider");
+  }
+  return context;
+}

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -6,12 +6,12 @@ export type { Address, CollateralSymbol, Dnum, Token, TokenSymbol };
 
 export type RiskLevel = "low" | "medium" | "high";
 
-export type CollIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export type CollIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type TroveId = `0x${string}`;
 export type PrefixedTroveId = `${CollIndex}:${TroveId}`;
 
 export function isCollIndex(value: unknown): value is CollIndex {
-  return typeof value === "number" && value >= 0 && value <= 9;
+  return typeof value === "number" && value >= 0 && value <= 7;
 }
 
 export function isTroveId(value: unknown): value is TroveId {
@@ -179,4 +179,69 @@ export interface CombinedTroveData {
   batchDebtShares: bigint;
   snapshotETH: bigint;
   snapshotBoldDebt: bigint;
+}
+
+export interface ReturnTroveReadCallData {
+  id: string;
+  troveId: string;
+  borrower: Address;
+  debt: bigint;
+  deposit: bigint;
+  interestRate: bigint;
+  status: TroveStatus;
+  collateral: {
+    id: string;
+    token: {
+      symbol: string;
+      name: string;
+    };
+    minCollRatio: number;
+    collIndex: number;
+  }
+  interestBatch: {
+    annualInterestRate: bigint;
+    batchManager: Address;
+  }
+  entireDebt: bigint;
+  entireColl: bigint;
+  redistBoldDebtGain: bigint;
+  redistCollGain: bigint;
+  accruedInterest: bigint;
+  recordedDebt: bigint;
+  annualInterestRate: bigint;
+  accruedBatchManagementFee: bigint;
+  lastInterestRateAdjTime: bigint;
+  stake: bigint;
+  lastDebtUpdateTime: bigint;
+  interestBatchManager: Address;
+  batchDebtShares: bigint;
+  snapshotETH: bigint;
+  snapshotBoldDebt: bigint;
+}
+
+export type DebtPerInterestRate = {
+  interestBatchManager: Address;
+  interestRate: bigint;
+  debt: bigint;
+}
+
+export enum TroveStatus {
+  nonExistent,
+  active,
+  closedByOwner,
+  closedByLiquidation,
+  zombie
+}
+
+export interface Trove {
+  debt: bigint;
+  coll: bigint;
+  stake: bigint;
+  status: TroveStatus;
+  arrayIndex: bigint;
+  lastDebtUpdateTime: bigint;
+  lastInterestRateAdjTime: bigint;
+  annualInterestRate: bigint;
+  interestBatchManager: Address;
+  batchDebtShares: bigint;
 }

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -161,3 +161,22 @@ export type Initiative =
 export type Vote = "for" | "against";
 export type VoteAllocation = { vote: Vote | null; value: Dnum };
 export type VoteAllocations = Record<Address, VoteAllocation>;
+
+export interface CombinedTroveData {
+  id: bigint;
+  entireDebt: bigint;
+  entireColl: bigint;
+  redistBoldDebtGain: bigint;
+  redistCollGain: bigint;
+  accruedInterest: bigint;
+  recordedDebt: bigint;
+  annualInterestRate: bigint;
+  accruedBatchManagementFee: bigint;
+  lastInterestRateAdjTime: bigint;
+  stake: bigint;
+  lastDebtUpdateTime: bigint;
+  interestBatchManager: Address;
+  batchDebtShares: bigint;
+  snapshotETH: bigint;
+  snapshotBoldDebt: bigint;
+}

--- a/frontend/app/src/types.ts
+++ b/frontend/app/src/types.ts
@@ -181,7 +181,7 @@ export interface CombinedTroveData {
   snapshotBoldDebt: bigint;
 }
 
-export interface ReturnTroveReadCallData {
+export interface ReturnCombinedTroveReadCallData {
   id: string;
   troveId: string;
   borrower: Address;
@@ -244,4 +244,25 @@ export interface Trove {
   annualInterestRate: bigint;
   interestBatchManager: Address;
   batchDebtShares: bigint;
+}
+
+export interface ReturnTroveReadCallData extends Trove {
+  id: string;
+  troveId: string;
+  borrower: Address;
+  deposit: bigint;
+  interestRate: bigint;
+  collateral: {
+    id: string;
+    token: {
+      symbol: string;
+      name: string;
+    };
+    minCollRatio: number;
+    collIndex: number;
+  }
+  interestBatch: {
+    annualInterestRate: bigint;
+    batchManager: Address;
+  }
 }

--- a/frontend/app/src/valibot-utils.ts
+++ b/frontend/app/src/valibot-utils.ts
@@ -38,8 +38,6 @@ export function vCollIndex() {
     v.literal(5),
     v.literal(6),
     v.literal(7),
-    v.literal(8),
-    v.literal(9),
   ]);
 }
 


### PR DESCRIPTION
closes #201 

Added direct read calls to contracts for loan positions and interest rates. Also added a subgraph error context to log and display error banner UI in case of any errors in log list.