### PR TITLE
Change subgraph query of interest rate brackets

### DIFF
--- a/frontend/app/src/graphql/gql.ts
+++ b/frontend/app/src/graphql/gql.ts
@@ -75,7 +75,7 @@ export function graphql(source: "\n  query InterestBatch($id: ID!) {\n    intere
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query AllInterestRateBrackets {\n    interestRateBrackets(orderBy: rate) {\n      collateral {\n        collIndex\n      }\n      rate\n      totalDebt\n    }\n  }\n"): typeof import('./graphql').AllInterestRateBracketsDocument;
+export function graphql(source: "\n  query AllInterestRateBrackets {\n    interestRateBrackets(\n      first: 1000\n      where: { totalDebt_gt: 0 }\n      orderBy: rate\n    ) {\n      collateral {\n        collIndex\n      }\n      rate\n      totalDebt\n    }\n  }\n"): typeof import('./graphql').AllInterestRateBracketsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/app/src/subgraph-queries.ts
+++ b/frontend/app/src/subgraph-queries.ts
@@ -240,7 +240,11 @@ export const InterestBatchQuery = graphql(`
 
 export const AllInterestRateBracketsQuery = graphql(`
   query AllInterestRateBrackets {
-    interestRateBrackets(orderBy: rate) {
+    interestRateBrackets(
+      first: 1000
+      where: { totalDebt_gt: 0 }
+      orderBy: rate
+    ) {
       collateral {
         collIndex
       }


### PR DESCRIPTION
closes #200 

Only have to update subgraph query of interest rate brackets to increase limit to 1000. Default of 100 was too limiting and led to underestimations in the debt-in-front calculations ([reference](https://github.com/liquity/bold/commit/30d7d8de3d4c2ab8528ad709b0fdf08af058f4cc)). Our frontend already debt-in-front per branch.