### PR TITLE
Add nerite.svg to permitted headers

### DIFF
--- a/frontend/app/next.config.js
+++ b/frontend/app/next.config.js
@@ -62,6 +62,17 @@ export default withBundleAnalyzer({
           },
         ],
       },
+      {
+        source: "/nerite.svg",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "Access-Control-Allow-Methods", value: "GET" },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Origin, Content-Type, Accept",
+          },
+        ],
+      },
     ];
   },
 });


### PR DESCRIPTION
Allows anyone to GET the `nerite.svg` icon from path