### PR TITLE
SHIP 🚀: Add refresh button to leaderboard page

### DIFF
--- a/frontend/app/src/app/shells/page.tsx
+++ b/frontend/app/src/app/shells/page.tsx
@@ -16,18 +16,18 @@ function getExpiryTime() {
   const utcMonth = now.getUTCMonth();
   const utcDate = now.getUTCDate();
   // 18:00 UTC today
-  const refreshTime = (new Date(Date.UTC(utcYear, utcMonth, utcDate, 18, 5, 0, 0))).getTime(); // 5 minutes after 18:00 UTC today
+  const refreshTime = Date.UTC(utcYear, utcMonth, utcDate, 18, 5, 0, 0); // 5 minutes after 18:00 UTC today
   if (refreshTime < now.getTime()) {
     return refreshTime + 1000 * 60 * 60 * 24;
   }
   return refreshTime;
 };
 
-async function getLeaderboardData() {
+async function getLeaderboardData(hardRefresh: boolean = false) {
   if (typeof localStorage !== 'undefined') {
     const leaderboardDataLS = localStorage.getItem(LOCAL_STORAGE_LEADERBOARD_DATA);
     const leaderboardDataExpiry = localStorage.getItem(LOCAL_STORAGE_LEADERBOARD_DATA_EXPIRY);
-    if (leaderboardDataLS && leaderboardDataExpiry && Number(leaderboardDataExpiry) > Date.now()) {
+    if (leaderboardDataLS && leaderboardDataExpiry && Number(leaderboardDataExpiry) >= Date.now() && !hardRefresh) {
       return JSON.parse(leaderboardDataLS) as LeaderboardResponse;
     }
   }
@@ -35,6 +35,8 @@ async function getLeaderboardData() {
   if (leaderboardData.success) {
     localStorage.setItem(LOCAL_STORAGE_LEADERBOARD_DATA, JSON.stringify(leaderboardData));
     localStorage.setItem(LOCAL_STORAGE_LEADERBOARD_DATA_EXPIRY, getExpiryTime().toString());
+  } else {
+    throw new Error(leaderboardData.error);
   }
   return leaderboardData;
 }
@@ -54,7 +56,7 @@ export default function ShellsPage() {
   const [error, setError] = useState<Error | null>(null);
 
   function refetch() {
-    getLeaderboardData()
+    getLeaderboardData(true)
       .then((data) => setLeaderboardData(data))
       .catch((error) => setError(error))
       .finally(() => setLoading(false));
@@ -193,84 +195,135 @@ export default function ShellsPage() {
           
           {/* Search Bar */}
           <div className={css({
-            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
             marginTop: 24,
-            maxWidth: '28rem'
+            maxWidth: '32rem'
           })}>
             <div className={css({
-              pointerEvents: 'none',
-              position: 'absolute',
-              insetY: 0,
-              left: 0,
-              display: 'flex',
-              alignItems: 'center',
-              paddingLeft: 12
+              position: 'relative',
+              flex: 1
             })}>
-              <svg className={css({
-                height: 20,
-                width: 20,
-                color: 'token(colors.gray:400)'
-              })} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </div>
-            <input
-              type="text"
-              placeholder="Search by address or ENS"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className={css({
-                display: 'block',
-                width: '100%',
-                borderRadius: 8,
-                border: '1px solid token(colors.gray:300)',
-                background: 'white',
-                paddingLeft: 40,
-                paddingRight: 40,
-                paddingY: 8,
-                fontSize: '0.875rem',
-                lineHeight: '1.25',
-                outline: 'none',
-                boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-                _placeholder: {
-                  color: 'token(colors.gray:500)'
-                },
-                _focus: {
-                  borderColor: 'token(colors.blue:500)',
-                  outline: 'none',
-                  ringWidth: 1,
-                  ringColor: 'token(colors.blue:500)'
-                }
-              })}
-            />
-            {searchQuery && (
-              <button
-                onClick={() => setSearchQuery('')}
-                className={css({
-                  position: 'absolute',
-                  insetY: 0,
-                  right: 0,
-                  paddingRight: 12,
-                  display: 'flex',
-                  alignItems: 'center',
-                  background: 'transparent',
-                  border: 'none',
-                  cursor: 'pointer'
-                })}
-                aria-label="Clear search"
-              >
+              <div className={css({
+                pointerEvents: 'none',
+                position: 'absolute',
+                insetY: 0,
+                left: 0,
+                display: 'flex',
+                alignItems: 'center',
+                paddingLeft: 12
+              })}>
                 <svg className={css({
                   height: 20,
                   width: 20,
-                  color: 'token(colors.gray:400)',
-                  _hover: {
-                    color: 'token(colors.gray:600)'
-                  }
+                  color: 'token(colors.gray:400)'
                 })} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>
-              </button>
-            )}
+              </div>
+              <input
+                type="text"
+                placeholder="Search by address or ENS"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className={css({
+                  display: 'block',
+                  width: '100%',
+                  borderRadius: 8,
+                  border: '1px solid token(colors.gray:300)',
+                  background: 'white',
+                  paddingLeft: 40,
+                  paddingRight: 40,
+                  paddingY: 8,
+                  fontSize: '0.875rem',
+                  lineHeight: '1.25',
+                  outline: 'none',
+                  boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                  _placeholder: {
+                    color: 'token(colors.gray:500)'
+                  },
+                  _focus: {
+                    borderColor: 'token(colors.blue:500)',
+                    outline: 'none',
+                    ringWidth: 1,
+                    ringColor: 'token(colors.blue:500)'
+                  }
+                })}
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery('')}
+                  className={css({
+                    position: 'absolute',
+                    insetY: 0,
+                    right: 0,
+                    paddingRight: 12,
+                    display: 'flex',
+                    alignItems: 'center',
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer'
+                  })}
+                  aria-label="Clear search"
+                >
+                  <svg className={css({
+                    height: 20,
+                    width: 20,
+                    color: 'token(colors.gray:400)',
+                    _hover: {
+                      color: 'token(colors.gray:600)'
+                    }
+                  })} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+            
+            {/* Refresh Button */}
+            <button
+              onClick={() => {
+                setLoading(true);
+                refetch();
+              }}
+              className={css({
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 8,
+                borderRadius: 8,
+                border: '1px solid token(colors.gray:300)',
+                background: 'white',
+                cursor: 'pointer',
+                boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+                transition: 'all 0.2s',
+                _hover: {
+                  background: 'token(colors.gray:50)',
+                  borderColor: 'token(colors.gray:400)'
+                },
+                _active: {
+                  transform: 'scale(0.95)'
+                }
+              })}
+              aria-label="Refresh leaderboard"
+              disabled={loading}
+            >
+              <svg 
+                className={css({
+                  height: 20,
+                  width: 20,
+                  color: loading ? 'token(colors.gray:400)' : 'token(colors.gray:600)',
+                  animation: loading ? 'spin 1s linear infinite' : undefined
+                })}
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
From PR #319 

A manual way to fetch latest shell points leaderboard data from the API endpoint in case of staleness in local cache.